### PR TITLE
Implement attendance list API and page filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Use this repository in alignment with the specifications in the `docs/` folder. 
 - Preserve the multi-tenant hierarchy (organization → facility → class) and the staff-facing web UX outlined in `docs/01_requirements.md`. Out-of-scope MVP items (guardian mobile app, billing, email delivery) must remain stubbed unless the specs change.
 - Keep user access within defined roles (system/organization/facility admins and staff). Design data filters and UI visibility to match those scopes.
 - When you open a PR, cite the specific doc sections that justify the change; explain how the work stays within spec.
+- Place implementation plans under the top-level `plan/` directory with numbered filenames (e.g., `01_*.md`) instead of `docs/`.
+- Commit and push changes frequently to keep the repository history granular and up to date.
 
 ## Data and schema alignment
 - Reflect the database updates in `docs/03_database.md` and `docs/08_database_additions.md`: adopt `m_guardians`, `_child_guardian`, `_child_sibling`, `r_report`, `h_report_share`, and treat guardian columns in `m_children` as deprecated, not authoritative.

--- a/app/api/attendance/list/route.ts
+++ b/app/api/attendance/list/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server"
+import { mockChildren, mockClasses } from "@/lib/mock-data"
+import type { AttendanceStatus } from "@/types/attendance"
+
+const weekdayLabels = ["日", "月", "火", "水", "木", "金", "土"] as const
+const weekdayNames = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const
+
+const gradeLabel = (age: number) => {
+  if (age >= 6) return "年長"
+  if (age === 5) return "年中"
+  return "年少"
+}
+
+const toKana = (name: string) => {
+  // 簡易的なダミー変換（デモ用）
+  return name.replace(/ /g, " ")
+}
+
+const buildCheckInTime = (childId: string, status: AttendanceStatus, date: string) => {
+  if (status === "absent" || status === "not_arrived") return { checked_in_at: null, checked_out_at: null }
+
+  const seed = childId.charCodeAt(0) + childId.length
+  const baseHour = status === "late" ? 10 : 8
+  const minutes = (seed * 7) % 50
+  const hour = baseHour + Math.floor(minutes / 60)
+  const paddedMinutes = String(minutes % 60).padStart(2, "0")
+
+  const checkIn = `${date}T${String(hour).padStart(2, "0")}:${paddedMinutes}:00+09:00`
+  const checkOutHour = Math.min(18, hour + 8)
+  const checkOut = `${date}T${String(checkOutHour).padStart(2, "0")}:${paddedMinutes}:00+09:00`
+
+  return {
+    checked_in_at: checkIn,
+    checked_out_at: status === "late" ? null : checkOut,
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+
+  const dateParam = searchParams.get("date")
+  const classId = searchParams.get("class_id")
+  const statusFilter = searchParams.get("status") as AttendanceStatus | null
+  const search = searchParams.get("search")?.trim()
+
+  const today = new Date()
+  const targetDate = dateParam ? new Date(dateParam) : today
+
+  if (Number.isNaN(targetDate.getTime())) {
+    return NextResponse.json({ success: false, error: "Invalid date" }, { status: 400 })
+  }
+
+  const isoDate = targetDate.toISOString().split("T")[0]
+  const weekday = targetDate.getDay()
+
+  const statusMap: Record<string, AttendanceStatus> = {
+    present: "present",
+    absent: "absent",
+    late: "late",
+    not_arrived: "not_arrived",
+  }
+
+  const children = mockChildren
+    .map((child) => {
+      const classInfo = mockClasses.find((cls) => cls.name === child.className) ?? {
+        id: child.className,
+        name: child.className,
+        childrenCount: mockChildren.filter((c) => c.className === child.className).length,
+      }
+
+      const status = statusMap[child.status as AttendanceStatus] ?? "not_arrived"
+      const { checked_in_at, checked_out_at } = buildCheckInTime(child.id, status, isoDate)
+
+      return {
+        child_id: child.id,
+        name: child.name,
+        kana: toKana(child.name),
+        class_id: classInfo.id,
+        class_name: classInfo.name,
+        grade: gradeLabel(child.age),
+        photo_url: "",
+        status,
+        is_expected: true,
+        is_unexpected: false,
+        checked_in_at,
+        checked_out_at,
+        scan_method: status === "present" || status === "late" ? "qr" : null,
+      }
+    })
+    .filter((child) => {
+      if (classId && child.class_id !== classId) return false
+      if (statusFilter && child.status !== statusFilter) return false
+      if (search && !(child.name.includes(search) || child.kana.includes(search))) return false
+      return true
+    })
+
+  const summary = {
+    total_children: children.length,
+    present_count: children.filter((child) => child.status === "present").length,
+    absent_count: children.filter((child) => child.status === "absent").length,
+    late_count: children.filter((child) => child.status === "late").length,
+    not_checked_in_count: children.filter((child) => child.status === "not_arrived").length,
+  }
+
+  const filters = {
+    classes: mockClasses.map((cls) => {
+      const presentCount = mockChildren.filter((child) => child.className === cls.name && child.status === "present").length
+      return {
+        class_id: cls.id,
+        class_name: cls.name,
+        present_count: presentCount,
+        total_count: mockChildren.filter((child) => child.className === cls.name).length,
+      }
+    }),
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      date: isoDate,
+      weekday: weekdayNames[weekday],
+      weekday_jp: weekdayLabels[weekday],
+      summary,
+      children,
+      filters,
+    },
+  })
+}

--- a/app/api/records/status/route.ts
+++ b/app/api/records/status/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server"
+import { mockChildren, mockClasses } from "@/lib/mock-data"
+
+const gradeLabel = (age: number) => {
+  if (age >= 6) return "年長"
+  if (age === 5) return "年中"
+  return "年少"
+}
+
+const toKana = (name: string) => {
+  // シンプルな疑似かな変換（デモ用）
+  return name.replace(/ /g, " ")
+}
+
+const buildDailyStatus = (childId: string, days: number) => {
+  const statuses: Array<"present" | "absent" | "late" | "none"> = []
+  for (let day = 1; day <= days; day++) {
+    const hash = (childId.charCodeAt(0) + day) % 11
+    if (hash % 5 === 0) {
+      statuses.push("absent")
+    } else if (hash % 4 === 0) {
+      statuses.push("late")
+    } else if (hash % 6 === 0) {
+      statuses.push("none")
+    } else {
+      statuses.push("present")
+    }
+  }
+  return statuses
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+
+  const yearParam = searchParams.get("year")
+  const monthParam = searchParams.get("month")
+  const classId = searchParams.get("class_id")
+  const search = searchParams.get("search")?.trim()
+  const warningOnly = searchParams.get("warning_only") === "true"
+
+  const today = new Date()
+  const year = yearParam ? parseInt(yearParam, 10) : today.getFullYear()
+  const month = monthParam ? parseInt(monthParam, 10) : today.getMonth() + 1
+
+  if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) {
+    return NextResponse.json({ success: false, error: "Invalid year or month" }, { status: 400 })
+  }
+
+  const daysInMonth = new Date(year, month, 0).getDate()
+  const startDate = `${year}-${String(month).padStart(2, "0")}-01`
+  const endDate = `${year}-${String(month).padStart(2, "0")}-${String(daysInMonth).padStart(2, "0")}`
+
+  const classLookup = Object.fromEntries(mockClasses.map((cls) => [cls.id, cls]))
+
+  const children = mockChildren
+    .map((child) => {
+      const dailyStatus = buildDailyStatus(child.id, daysInMonth)
+      const monthlyAttendanceCount = dailyStatus.filter((status) => status === "present" || status === "late").length
+      const monthlyRecordCount = dailyStatus.filter((status) => status === "present").length
+      const yearlyAttendanceCount = monthlyAttendanceCount * month
+      const yearlyRecordCount = monthlyRecordCount * month
+
+      const lastRecordedIndex = dailyStatus.lastIndexOf("present")
+      const lastRecordDate = lastRecordedIndex >= 0
+        ? `${year}-${String(month).padStart(2, "0")}-${String(lastRecordedIndex + 1).padStart(2, "0")}`
+        : null
+
+      const classInfo = Object.values(classLookup).find((cls) => cls.name === child.className) ?? {
+        id: child.className,
+        name: child.className,
+      }
+
+      return {
+        child_id: child.id,
+        name: child.name,
+        kana: toKana(child.name),
+        class_id: classInfo.id,
+        class_name: classInfo.name,
+        grade: gradeLabel(child.age),
+        photo_url: "",
+        last_record_date: lastRecordDate,
+        is_recorded_today: dailyStatus[new Date().getDate() - 1] === "present",
+        monthly: {
+          attendance_count: monthlyAttendanceCount,
+          record_count: monthlyRecordCount,
+          record_rate: monthlyAttendanceCount === 0 ? 0 : Math.round((monthlyRecordCount / monthlyAttendanceCount) * 1000) / 10,
+          daily_status: dailyStatus,
+        },
+        yearly: {
+          attendance_count: yearlyAttendanceCount,
+          record_count: yearlyRecordCount,
+          record_rate: yearlyAttendanceCount === 0 ? 0 : Math.round((yearlyRecordCount / yearlyAttendanceCount) * 1000) / 10,
+        },
+      }
+    })
+    .filter((child) => {
+      if (classId && child.class_id !== classId) return false
+      if (search && !(child.name.includes(search) || child.kana.includes(search))) return false
+      if (warningOnly && child.monthly.record_rate >= 80) return false
+      return true
+    })
+
+  const summary = {
+    total_children: children.length,
+    warning_children: children.filter((child) => child.monthly.record_rate < 80).length,
+    average_record_rate:
+      children.length === 0
+        ? 0
+        : Math.round(
+            (children.reduce((acc, child) => acc + child.monthly.record_rate, 0) / children.length) * 10,
+          ) / 10,
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      period: {
+        year,
+        month,
+        start_date: startDate,
+        end_date: endDate,
+        days_in_month: daysInMonth,
+      },
+      children,
+      summary,
+      filters: {
+        classes: mockClasses.map((cls) => ({ class_id: cls.id, class_name: cls.name })),
+      },
+    },
+  })
+}

--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -1,61 +1,260 @@
-import { StaffLayout } from "@/components/layout/staff-layout"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { mockChildren } from "@/lib/mock-data"
+"use client"
 
-const statusLabels: Record<string, { label: string; variant: "default" | "secondary" | "destructive" }> = {
+import { useEffect, useMemo, useState } from "react"
+import { StaffLayout } from "@/components/layout/staff-layout"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { AlertCircle, Calendar, RefreshCw, Search, Users } from "lucide-react"
+
+import type { AttendanceStatus } from "@/types/attendance"
+
+type AttendanceChild = {
+  child_id: string
+  name: string
+  kana: string
+  class_id: string
+  class_name: string
+  grade: string
+  status: AttendanceStatus
+  is_expected: boolean
+  is_unexpected: boolean
+  checked_in_at: string | null
+  checked_out_at: string | null
+  scan_method: "manual" | "qr" | "nfc" | null
+}
+
+type AttendanceResponse = {
+  success: boolean
+  data?: {
+    date: string
+    weekday: string
+    weekday_jp: string
+    summary: {
+      total_children: number
+      present_count: number
+      absent_count: number
+      late_count: number
+      not_checked_in_count: number
+    }
+    children: AttendanceChild[]
+    filters: {
+      classes: { class_id: string; class_name: string; present_count: number; total_count: number }[]
+    }
+  }
+  error?: string
+}
+
+const statusStyle: Record<AttendanceStatus, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
   present: { label: "出席", variant: "default" },
   absent: { label: "欠席", variant: "secondary" },
   late: { label: "遅刻", variant: "destructive" },
+  not_arrived: { label: "未到着", variant: "outline" },
 }
 
 export default function AttendanceListPage() {
-  const presentCount = mockChildren.filter((c) => c.status === "present").length
-  const absentCount = mockChildren.filter((c) => c.status === "absent").length
+  const today = new Date().toISOString().split("T")[0]
+  const [date, setDate] = useState(today)
+  const [selectedClass, setSelectedClass] = useState<string>("all")
+  const [selectedStatus, setSelectedStatus] = useState<"all" | AttendanceStatus>("all")
+  const [search, setSearch] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<AttendanceResponse["data"] | null>(null)
+
+  const fetchAttendance = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    const params = new URLSearchParams()
+    params.set("date", date)
+    if (selectedClass !== "all") params.set("class_id", selectedClass)
+    if (selectedStatus !== "all") params.set("status", selectedStatus)
+    if (search.trim()) params.set("search", search.trim())
+
+    const res = await fetch(`/api/attendance/list?${params.toString()}`)
+    const json: AttendanceResponse = await res.json()
+
+    if (!res.ok || !json.success) {
+      setError(json.error || "データの取得に失敗しました")
+      setData(null)
+    } else {
+      setData(json.data ?? null)
+    }
+
+    setIsLoading(false)
+  }
+
+  useEffect(() => {
+    fetchAttendance()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date, selectedClass, selectedStatus, search])
+
+  const sortedChildren = useMemo(() => {
+    if (!data) return []
+    return [...data.children].sort((a, b) => a.class_name.localeCompare(b.class_name) || a.kana.localeCompare(b.kana))
+  }, [data])
 
   return (
     <StaffLayout title="出席児童一覧" subtitle="本日の出席状況">
       <div className="space-y-6">
-        <div className="grid gap-4 sm:grid-cols-3">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">出席</p>
-              <p className="text-3xl font-bold text-primary">{presentCount}名</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">欠席</p>
-              <p className="text-3xl font-bold">{absentCount}名</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">合計</p>
-              <p className="text-3xl font-bold">{mockChildren.length}名</p>
-            </CardContent>
-          </Card>
-        </div>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between gap-4">
+            <div>
+              <CardTitle>本日の出席状況</CardTitle>
+              {data && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {data.date}（{data.weekday_jp}） 時点
+                </p>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm">
+                <Calendar className="h-4 w-4 text-muted-foreground" />
+                <input
+                  type="date"
+                  className="bg-transparent text-sm focus:outline-none"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                />
+              </div>
+              <Button variant="outline" size="sm" onClick={fetchAttendance} disabled={isLoading}>
+                <RefreshCw className={`mr-2 h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
+                再取得
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {error ? (
+              <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/5 p-3 text-destructive">
+                <AlertCircle className="h-5 w-5" />
+                <p className="text-sm">{error}</p>
+              </div>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <SummaryTile label="出席" value={data?.summary.present_count ?? 0} highlight />
+                <SummaryTile label="欠席" value={data?.summary.absent_count ?? 0} />
+                <SummaryTile label="遅刻" value={data?.summary.late_count ?? 0} />
+                <SummaryTile label="未到着" value={data?.summary.not_checked_in_count ?? 0} />
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
         <Card>
           <CardHeader>
-            <CardTitle>児童一覧</CardTitle>
+            <CardTitle>絞り込み</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-2">
-              {mockChildren.map((child) => (
-                <div key={child.id} className="flex items-center justify-between rounded-lg border border-border p-3">
-                  <div>
-                    <p className="font-medium">{child.name}</p>
-                    <p className="text-sm text-muted-foreground">{child.className}</p>
-                  </div>
-                  <Badge variant={statusLabels[child.status].variant}>{statusLabels[child.status].label}</Badge>
+            <div className="grid gap-4 md:grid-cols-4">
+              <div className="space-y-2">
+                <Label>クラス</Label>
+                <Select value={selectedClass} onValueChange={setSelectedClass} disabled={isLoading}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="全クラス" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">全クラス</SelectItem>
+                    {data?.filters.classes.map((cls) => (
+                      <SelectItem key={cls.class_id} value={cls.class_id}>
+                        {cls.class_name}（{cls.present_count}/{cls.total_count}）
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>ステータス</Label>
+                <Select value={selectedStatus} onValueChange={(value) => setSelectedStatus(value as AttendanceStatus | "all")} disabled={isLoading}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="すべて" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">すべて</SelectItem>
+                    <SelectItem value="present">出席</SelectItem>
+                    <SelectItem value="absent">欠席</SelectItem>
+                    <SelectItem value="late">遅刻</SelectItem>
+                    <SelectItem value="not_arrived">未到着</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2 md:col-span-2">
+                <Label>検索</Label>
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    placeholder="名前・かなで検索"
+                    className="pl-9"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    disabled={isLoading}
+                  />
                 </div>
-              ))}
+              </div>
             </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between gap-4">
+            <CardTitle>児童一覧</CardTitle>
+            {data && (
+              <p className="text-sm text-muted-foreground">
+                {data.summary.total_children}名表示
+              </p>
+            )}
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <p className="text-sm text-muted-foreground">読込中...</p>
+            ) : sortedChildren.length === 0 ? (
+              <p className="text-sm text-muted-foreground">該当する児童がいません</p>
+            ) : (
+              <div className="space-y-3">
+                {sortedChildren.map((child) => (
+                  <div
+                    key={child.child_id}
+                    className="flex flex-col gap-3 rounded-lg border border-border p-3 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium">{child.name}</p>
+                        <Badge variant={statusStyle[child.status].variant}>{statusStyle[child.status].label}</Badge>
+                        {!child.is_expected && <Badge variant="outline">予定外</Badge>}
+                      </div>
+                      <p className="text-sm text-muted-foreground">{child.class_name} / {child.grade}</p>
+                      <p className="text-xs text-muted-foreground">かな: {child.kana}</p>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <span className="flex items-center gap-1">
+                          <Users className="h-3 w-3" />
+                          {child.is_expected ? "出席予定" : "出席予定なし"}
+                        </span>
+                        <span>チェックイン: {child.checked_in_at ? new Date(child.checked_in_at).toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }) : "-"}</span>
+                        <span>チェックアウト: {child.checked_out_at ? new Date(child.checked_out_at).toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }) : "-"}</span>
+                        <span>方法: {child.scan_method ? child.scan_method.toUpperCase() : "未登録"}</span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>
     </StaffLayout>
+  )
+}
+
+function SummaryTile({ label, value, highlight = false }: { label: string; value: number; highlight?: boolean }) {
+  return (
+    <div className={`rounded-lg border p-4 ${highlight ? "bg-primary/5 border-primary/30" : "bg-card"}`}>
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className={`text-3xl font-bold ${highlight ? "text-primary" : "text-foreground"}`}>{value}名</p>
+    </div>
   )
 }

--- a/app/records/status/page.tsx
+++ b/app/records/status/page.tsx
@@ -1,20 +1,65 @@
 "use client"
 
-import React, { useState, useMemo } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { StaffLayout } from "@/components/layout/staff-layout"
 import { FileText, ChevronLeft, Calendar, ChevronRight, ChevronDown, Search, Filter, History, ArrowUp, ArrowDown } from "lucide-react"
-import { mockChildren } from "@/lib/mock-data"
+
+
+type RecordStatusChild = {
+    child_id: string
+    name: string
+    kana: string
+    class_id: string
+    class_name: string
+    grade: string
+    photo_url: string
+    last_record_date: string | null
+    is_recorded_today: boolean
+    monthly: {
+        attendance_count: number
+        record_count: number
+        record_rate: number
+        daily_status: ("present" | "absent" | "late" | "none")[]
+    }
+    yearly: {
+        attendance_count: number
+        record_count: number
+        record_rate: number
+    }
+}
+
+type RecordStatusResponse = {
+    success: true
+    data: {
+        period: {
+            year: number
+            month: number
+            start_date: string
+            end_date: string
+            days_in_month: number
+        }
+        children: RecordStatusChild[]
+        summary: {
+            total_children: number
+            warning_children: number
+            average_record_rate: number
+        }
+        filters: {
+            classes: { class_id: string; class_name: string }[]
+        }
+    }
+}
 
 // --- Helper Components ---
 
-const SortIcon = ({ colKey, currentSort, onSort }: { colKey: string, currentSort?: { key: string, order: 'asc' | 'desc' }, onSort?: (key: string) => void }) => {
+const SortIcon = ({ colKey, currentSort }: { colKey: string, currentSort?: { key: string, order: 'asc' | 'desc' } }) => {
     if (!currentSort || currentSort.key !== colKey) {
         return <span className="ml-1 text-slate-300">↕</span>
     }
     return currentSort.order === 'asc' ? <ArrowUp className="ml-1 inline h-3 w-3" /> : <ArrowDown className="ml-1 inline h-3 w-3" />
 }
 
-const LastRecordBadge = ({ dateStr }: { dateStr: string }) => {
+const LastRecordBadge = ({ dateStr }: { dateStr: string | null }) => {
     if (!dateStr) return <span className="text-xs text-slate-400">-</span>
     const date = new Date(dateStr)
     const isToday = new Date().toDateString() === date.toDateString()
@@ -26,13 +71,14 @@ const LastRecordBadge = ({ dateStr }: { dateStr: string }) => {
 }
 
 const ProgressBar = ({ value, max, mini = false }: { value: number, max: number, mini?: boolean }) => {
-    const percentage = Math.min(100, Math.max(0, (value / max) * 100)) || 0
+    const safeMax = max || 1
+    const percentage = Math.min(100, Math.max(0, (value / safeMax) * 100)) || 0
     const colorClass = percentage >= 80 ? 'bg-green-500' : percentage >= 50 ? 'bg-yellow-500' : 'bg-red-500'
 
     return (
         <div className="w-full">
             <div className="flex justify-between text-xs mb-1">
-                {!mini && <span className="font-medium">{percentage.toFixed(0)}%</span>}
+                {!mini && <span className="font-medium">{percentage.toFixed(1)}%</span>}
                 <span className="text-slate-500">{value}/{max}</span>
             </div>
             <div className={`w-full bg-slate-100 rounded-full ${mini ? 'h-1.5' : 'h-2.5'}`}>
@@ -59,71 +105,88 @@ const MonthlyHeatmap = ({ history }: { history: ('present' | 'absent' | 'late' |
     )
 }
 
+const formatMonth = (year: number, month: number) => `${year}年 ${month}月`
+
+const getSortValue = (child: RecordStatusChild, key: string) => {
+    switch (key) {
+        case 'name':
+            return child.name
+        case 'grade':
+            return child.grade
+        case 'class_name':
+            return child.class_name
+        case 'last_record_date':
+            return child.last_record_date || ''
+        case 'record_rate':
+            return child.monthly.record_rate
+        case 'yearly_record_rate':
+            return child.yearly.record_rate
+        default:
+            return ''
+    }
+}
+
 // --- Main Component ---
 
 export default function StatusPage() {
+    const today = new Date()
+    const [year, setYear] = useState(today.getFullYear())
+    const [month, setMonth] = useState(today.getMonth() + 1)
     const [selectedClass, setSelectedClass] = useState('All')
     const [searchTerm, setSearchTerm] = useState('')
     const [warningOnly, setWarningOnly] = useState(false)
     const [sortConfig, setSortConfig] = useState<{ key: string, order: 'asc' | 'desc' }>({ key: 'name', order: 'asc' })
 
-    // Enrich mock data with missing fields
-    const enrichedData = useMemo(() => {
-        return mockChildren.map(child => {
-            // Generate fake stats
-            const monthlyAttendance = 20
-            const monthlyRecords = Math.floor(Math.random() * 21)
-            const yearlyAttendance = 200
-            const yearlyRecords = Math.floor(Math.random() * 201)
+    const [data, setData] = useState<RecordStatusResponse['data'] | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
 
-            // Generate fake history
-            const history: ('present' | 'absent' | 'late' | 'none')[] = Array(31).fill('none').map(() => {
-                const r = Math.random()
-                if (r > 0.8) return 'absent'
-                if (r > 0.7) return 'late'
-                if (r > 0.3) return 'present'
-                return 'none'
+    useEffect(() => {
+        const controller = new AbortController()
+        const params = new URLSearchParams({ year: String(year), month: String(month) })
+        if (selectedClass !== 'All') params.set('class_id', selectedClass)
+        if (searchTerm) params.set('search', searchTerm)
+        if (warningOnly) params.set('warning_only', 'true')
+
+        setLoading(true)
+        setError(null)
+
+        fetch(`/api/records/status?${params.toString()}`, { signal: controller.signal })
+            .then(async (res) => {
+                if (!res.ok) {
+                    const body = await res.json().catch(() => ({}))
+                    throw new Error(body.error || '一覧の取得に失敗しました')
+                }
+                return res.json() as Promise<RecordStatusResponse>
+            })
+            .then((json) => {
+                setData(json.data)
+            })
+            .catch((err) => {
+                if (err.name !== 'AbortError') {
+                    setError(err.message)
+                }
+            })
+            .finally(() => {
+                setLoading(false)
             })
 
-            return {
-                ...child,
-                grade: child.age === 6 ? '年長' : child.age === 5 ? '年中' : '年少',
-                kana: 'かな', // Mock kana
-                last_record_date: '2024-01-15',
-                monthly_record_count: monthlyRecords,
-                monthly_attendance_count: monthlyAttendance,
-                record_rate: (monthlyRecords / monthlyAttendance) * 100,
-                yearly_record_count: yearlyRecords,
-                yearly_attendance_count: yearlyAttendance,
-                yearly_rate: (yearlyRecords / yearlyAttendance) * 100,
-                record_history: history
-            }
-        })
-    }, [])
-
-    const uniqueClasses = ['All', ...Array.from(new Set(mockChildren.map(c => c.className)))]
-
-    const filteredData = useMemo(() => {
-        return enrichedData.filter(child => {
-            const matchesClass = selectedClass === 'All' || child.className === selectedClass
-            const matchesSearch = child.name.includes(searchTerm) || child.kana.includes(searchTerm)
-            const matchesWarning = !warningOnly || (child.record_rate < 80)
-            return matchesClass && matchesSearch && matchesWarning
-        })
-    }, [enrichedData, selectedClass, searchTerm, warningOnly])
+        return () => controller.abort()
+    }, [year, month, selectedClass, searchTerm, warningOnly])
 
     const sortedData = useMemo(() => {
-        const sorted = [...filteredData]
+        if (!data) return []
+        const sorted = [...data.children]
         sorted.sort((a, b) => {
-            const aValue = a[sortConfig.key as keyof typeof a]
-            const bValue = b[sortConfig.key as keyof typeof b]
+            const aValue = getSortValue(a, sortConfig.key)
+            const bValue = getSortValue(b, sortConfig.key)
 
             if (aValue < bValue) return sortConfig.order === 'asc' ? -1 : 1
             if (aValue > bValue) return sortConfig.order === 'asc' ? 1 : -1
             return 0
         })
         return sorted
-    }, [filteredData, sortConfig])
+    }, [data, sortConfig])
 
     const handleSort = (key: string) => {
         setSortConfig(current => ({
@@ -131,6 +194,30 @@ export default function StatusPage() {
             order: current.key === key && current.order === 'asc' ? 'desc' : 'asc'
         }))
     }
+
+    const goPrevMonth = () => {
+        setMonth(prev => {
+            if (prev === 1) {
+                setYear((y) => y - 1)
+                return 12
+            }
+            return prev - 1
+        })
+    }
+
+    const goNextMonth = () => {
+        setMonth(prev => {
+            if (prev === 12) {
+                setYear((y) => y + 1)
+                return 1
+            }
+            return prev + 1
+        })
+    }
+
+    const classOptions = data?.filters.classes ?? []
+    const summary = data?.summary
+    const period = data?.period
 
     return (
         <StaffLayout title="全児童 月間記録管理">
@@ -150,14 +237,14 @@ export default function StatusPage() {
             {/* Actions */}
             <div className="flex items-center gap-3 mt-4">
                 <div className="flex items-center bg-white border border-slate-200 rounded-lg p-1 shadow-sm">
-                    <button className="p-1 hover:bg-slate-100 rounded text-slate-400">
+                    <button className="p-1 hover:bg-slate-100 rounded text-slate-400" onClick={goPrevMonth}>
                         <ChevronLeft className="w-4 h-4" />
                     </button>
                     <div className="flex items-center text-sm font-bold text-slate-700 px-3">
                         <Calendar className="w-4 h-4 mr-2 text-indigo-500" />
-                        2023年 10月
+                        {period ? formatMonth(period.year, period.month) : formatMonth(year, month)}
                     </div>
-                    <button className="p-1 hover:bg-slate-100 rounded text-slate-400">
+                    <button className="p-1 hover:bg-slate-100 rounded text-slate-400" onClick={goNextMonth}>
                         <ChevronRight className="w-4 h-4" />
                     </button>
                 </div>
@@ -170,14 +257,15 @@ export default function StatusPage() {
 
             {/* Filter Bar */}
             <div className="py-3 border-t border-slate-100 flex flex-col md:flex-row md:items-center gap-4 mt-4">
-                <div className="relative min-w-[140px]">
+                <div className="relative min-w-[180px]">
                     <select
                         className="w-full appearance-none bg-white border border-slate-300 text-slate-700 py-2 pl-3 pr-8 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-indigo-500"
                         value={selectedClass}
                         onChange={(e) => setSelectedClass(e.target.value)}
                     >
-                        {uniqueClasses.map(cls => (
-                            <option key={cls} value={cls}>{cls === 'All' ? '全クラス' : cls}</option>
+                        <option value="All">全クラス</option>
+                        {classOptions.map(cls => (
+                            <option key={cls.class_id} value={cls.class_id}>{cls.class_name}</option>
                         ))}
                     </select>
                     <ChevronDown className="absolute right-2.5 top-2.5 w-4 h-4 text-slate-400 pointer-events-none" />
@@ -212,154 +300,184 @@ export default function StatusPage() {
                 </label>
             </div>
 
+            {error && (
+                <div className="mt-4 p-4 bg-rose-50 border border-rose-200 text-rose-700 rounded-md text-sm">
+                    {error}
+                </div>
+            )}
+
             {/* --- Main Table Section --- */}
             <main className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
+                {loading && (
+                    <div className="text-center text-slate-500 py-10 text-sm">読み込み中...</div>
+                )}
 
-                {/* Table Stats */}
-                <div className="mb-4 flex items-center justify-between text-sm text-slate-500">
-                    <div>
-                        表示中: <span className="font-bold text-slate-900">{filteredData.length}</span> 名
-                        {warningOnly && <span className="ml-2 text-rose-600 bg-rose-50 px-2 py-0.5 rounded text-xs font-bold">要確認対象</span>}
-                    </div>
-                    <div className="flex items-center gap-4 text-xs">
-                        <div className="flex items-center gap-1.5"><div className="w-3 h-3 bg-indigo-600 rounded-sm"></div> 記録済</div>
-                        <div className="flex items-center gap-1.5"><div className="w-3 h-3 bg-amber-400 rounded-sm"></div> 記録なし(在所)</div>
-                        <div className="flex items-center gap-1.5"><div className="w-3 h-3 bg-slate-200 rounded-sm"></div> 休み</div>
-                    </div>
-                </div>
+                {!loading && data && (
+                    <>
+                        {/* Table Stats */}
+                        <div className="mb-4 flex items-center justify-between text-sm text-slate-500">
+                            <div>
+                                表示中: <span className="font-bold text-slate-900">{data.children.length}</span> 名
+                                {warningOnly && <span className="ml-2 text-rose-600 bg-rose-50 px-2 py-0.5 rounded text-xs font-bold">要確認対象</span>}
+                            </div>
+                            <div className="flex items-center gap-4 text-xs">
+                                <div className="flex items-center gap-1.5"><div className="w-3 h-3 bg-indigo-600 rounded-sm"></div> 記録済</div>
+                                <div className="flex items-center gap-1.5"><div className="w-3 h-3 bg-amber-400 rounded-sm"></div> 記録なし(在所)</div>
+                                <div className="flex items-center gap-1.5"><div className="w-3 h-3 bg-slate-200 rounded-sm"></div> 休み</div>
+                                <div className="flex items-center gap-1.5"><div className="w-3 h-3 bg-slate-100 rounded-sm"></div> データなし</div>
+                            </div>
+                        </div>
 
-                {/* --- Scrollable Table Wrapper --- */}
-                <div className="w-full bg-white border border-slate-200 shadow-sm overflow-hidden flex flex-col">
-                    <div className="overflow-x-auto">
-                        <table className="min-w-full divide-y divide-slate-200">
-                            <thead className="bg-slate-50 border-b border-slate-200">
-                                <tr>
-                                    {/* Sticky Column: Name Only */}
-                                    <th
-                                        scope="col"
-                                        className="sticky left-0 z-20 bg-slate-50 px-6 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[180px] shadow-[4px_0_8px_-4px_rgba(0,0,0,0.1)] cursor-pointer hover:bg-slate-100 transition-colors"
-                                        onClick={() => handleSort('name')}
-                                    >
-                                        氏名 <SortIcon colKey="name" currentSort={sortConfig} />
-                                    </th>
+                        {summary && (
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
+                                <div className="p-4 bg-white border border-slate-200 rounded-lg shadow-sm">
+                                    <div className="text-xs text-slate-500 mb-1">平均記録率</div>
+                                    <div className="text-2xl font-bold text-slate-900">{summary.average_record_rate.toFixed(1)}%</div>
+                                </div>
+                                <div className="p-4 bg-white border border-slate-200 rounded-lg shadow-sm">
+                                    <div className="text-xs text-slate-500 mb-1">合計児童</div>
+                                    <div className="text-2xl font-bold text-slate-900">{summary.total_children}名</div>
+                                </div>
+                                <div className="p-4 bg-white border border-slate-200 rounded-lg shadow-sm">
+                                    <div className="text-xs text-slate-500 mb-1">要注意</div>
+                                    <div className="text-2xl font-bold text-rose-600">{summary.warning_children}名</div>
+                                </div>
+                            </div>
+                        )}
 
-                                    {/* New Column: Grade & Class */}
-                                    <th
-                                        scope="col"
-                                        className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[120px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
-                                        onClick={() => handleSort('grade')}
-                                    >
-                                        学年・クラス <SortIcon colKey="grade" currentSort={sortConfig} />
-                                    </th>
+                        {/* --- Scrollable Table Wrapper --- */}
+                        <div className="w-full bg-white border border-slate-200 shadow-sm overflow-hidden flex flex-col">
+                            <div className="overflow-x-auto">
+                                <table className="min-w-full divide-y divide-slate-200">
+                                    <thead className="bg-slate-50 border-b border-slate-200">
+                                        <tr>
+                                            {/* Sticky Column: Name Only */}
+                                            <th
+                                                scope="col"
+                                                className="sticky left-0 z-20 bg-slate-50 px-6 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[180px] shadow-[4px_0_8px_-4px_rgba(0,0,0,0.1)] cursor-pointer hover:bg-slate-100 transition-colors"
+                                                onClick={() => handleSort('name')}
+                                            >
+                                                氏名 <SortIcon colKey="name" currentSort={sortConfig} />
+                                            </th>
 
-                                    <th
-                                        scope="col"
-                                        className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[120px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
-                                        onClick={() => handleSort('last_record_date')}
-                                    >
-                                        最終更新 <SortIcon colKey="last_record_date" currentSort={sortConfig} />
-                                    </th>
+                                            {/* New Column: Grade & Class */}
+                                            <th
+                                                scope="col"
+                                                className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[160px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
+                                                onClick={() => handleSort('grade')}
+                                            >
+                                                学年・クラス <SortIcon colKey="grade" currentSort={sortConfig} />
+                                            </th>
 
-                                    <th
-                                        scope="col"
-                                        className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[180px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
-                                        onClick={() => handleSort('record_rate')}
-                                    >
-                                        月間記録率 <SortIcon colKey="record_rate" currentSort={sortConfig} />
-                                    </th>
+                                            <th
+                                                scope="col"
+                                                className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[140px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
+                                                onClick={() => handleSort('last_record_date')}
+                                            >
+                                                最終更新 <SortIcon colKey="last_record_date" currentSort={sortConfig} />
+                                            </th>
 
-                                    <th scope="col" className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[350px]">
-                                        月間ヒートマップ(1日〜31日)
-                                    </th>
+                                            <th
+                                                scope="col"
+                                                className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[180px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
+                                                onClick={() => handleSort('record_rate')}
+                                            >
+                                                月間記録率 <SortIcon colKey="record_rate" currentSort={sortConfig} />
+                                            </th>
 
-                                    {/* New Column: Yearly Rate */}
-                                    <th
-                                        scope="col"
-                                        className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[140px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
-                                        onClick={() => handleSort('yearly_rate')}
-                                    >
-                                        年間割合 <SortIcon colKey="yearly_rate" currentSort={sortConfig} />
-                                    </th>
+                                            <th scope="col" className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[350px]">
+                                                月間ヒートマップ(1日〜{period?.days_in_month ?? 31}日)
+                                            </th>
 
-                                    <th scope="col" className="px-4 py-4 text-right text-xs font-bold text-slate-500 uppercase tracking-wider w-[120px]">
-                                        アクション
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody className="bg-white divide-y divide-slate-200">
-                                {sortedData.length > 0 ? (
-                                    sortedData.map((child) => (
-                                        <tr key={child.id} className="hover:bg-slate-50 transition-colors group">
+                                            <th
+                                                scope="col"
+                                                className="px-4 py-4 text-left text-xs font-bold text-slate-500 uppercase tracking-wider w-[140px] whitespace-nowrap cursor-pointer hover:bg-slate-100"
+                                                onClick={() => handleSort('yearly_record_rate')}
+                                            >
+                                                年間割合 <SortIcon colKey="yearly_record_rate" currentSort={sortConfig} />
+                                            </th>
 
-                                            {/* Sticky Column: Name */}
-                                            <td className="sticky left-0 z-20 bg-white px-6 py-4 whitespace-nowrap shadow-[4px_0_8px_-4px_rgba(0,0,0,0.1)] group-hover:bg-slate-50 transition-colors">
-                                                <div className="flex flex-col">
-                                                    <span className="text-sm font-bold text-slate-900">{child.name}</span>
-                                                    <span className="text-xs text-slate-400">{child.kana}</span>
-                                                </div>
-                                            </td>
-
-                                            {/* Grade & Class */}
-                                            <td className="px-4 py-4 whitespace-nowrap">
-                                                <div className="flex flex-col">
-                                                    <span className="text-sm font-medium text-slate-900">{child.grade}</span>
-                                                    <span className="text-xs text-slate-500">{child.className}</span>
-                                                </div>
-                                            </td>
-
-                                            {/* Last Record */}
-                                            <td className="px-4 py-4 whitespace-nowrap">
-                                                <LastRecordBadge dateStr={child.last_record_date} />
-                                            </td>
-
-                                            {/* Monthly Stats */}
-                                            <td className="px-4 py-4 whitespace-nowrap align-middle">
-                                                <ProgressBar value={child.monthly_record_count} max={child.monthly_attendance_count} />
-                                            </td>
-
-                                            {/* Monthly Heatmap */}
-                                            <td className="px-4 py-4 whitespace-nowrap">
-                                                <MonthlyHeatmap history={child.record_history} />
-                                            </td>
-
-                                            {/* Yearly Rate (New) */}
-                                            <td className="px-4 py-4 whitespace-nowrap align-middle">
-                                                <ProgressBar value={child.yearly_record_count} max={child.yearly_attendance_count} mini={true} />
-                                            </td>
-
-                                            {/* Actions (Always Visible) */}
-                                            <td className="px-4 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                                <div className="flex items-center justify-end gap-2">
-                                                    <button className="text-slate-400 hover:text-indigo-600 p-2 rounded-full hover:bg-indigo-50 transition-colors" title="履歴">
-                                                        <History className="w-4 h-4" />
-                                                    </button>
-                                                    <button className="bg-white border border-indigo-200 text-indigo-600 hover:bg-indigo-50 hover:border-indigo-300 px-3 py-1.5 rounded-md text-xs font-bold shadow-sm transition-all">
-                                                        作成
-                                                    </button>
-                                                </div>
-                                            </td>
+                                            <th scope="col" className="px-4 py-4 text-right text-xs font-bold text-slate-500 uppercase tracking-wider w-[120px]">
+                                                アクション
+                                            </th>
                                         </tr>
-                                    ))
-                                ) : (
-                                    <tr>
-                                        <td colSpan={7} className="px-6 py-12 text-center text-slate-400">
-                                            <div className="flex flex-col items-center gap-2">
-                                                <Filter className="w-8 h-8 text-slate-300" />
-                                                <span className="text-sm">条件に一致する児童はいません</span>
-                                                <button
-                                                    onClick={() => { setSearchTerm(''); setWarningOnly(false); setSelectedClass('All'); }}
-                                                    className="text-indigo-600 text-sm hover:underline mt-1"
-                                                >
-                                                    フィルターをリセット
-                                                </button>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                                    </thead>
+                                    <tbody className="bg-white divide-y divide-slate-200">
+                                        {sortedData.length > 0 ? (
+                                            sortedData.map((child) => (
+                                                <tr key={child.child_id} className="hover:bg-slate-50 transition-colors group">
+
+                                                    {/* Sticky Column: Name */}
+                                                    <td className="sticky left-0 z-20 bg-white px-6 py-4 whitespace-nowrap shadow-[4px_0_8px_-4px_rgba(0,0,0,0.1)] group-hover:bg-slate-50 transition-colors">
+                                                        <div className="flex flex-col">
+                                                            <span className="text-sm font-bold text-slate-900">{child.name}</span>
+                                                            <span className="text-xs text-slate-400">{child.kana}</span>
+                                                        </div>
+                                                    </td>
+
+                                                    {/* Grade & Class */}
+                                                    <td className="px-4 py-4 whitespace-nowrap">
+                                                        <div className="flex flex-col">
+                                                            <span className="text-sm font-medium text-slate-900">{child.grade}</span>
+                                                            <span className="text-xs text-slate-500">{child.class_name}</span>
+                                                        </div>
+                                                    </td>
+
+                                                    {/* Last Record */}
+                                                    <td className="px-4 py-4 whitespace-nowrap">
+                                                        <LastRecordBadge dateStr={child.last_record_date} />
+                                                    </td>
+
+                                                    {/* Monthly Stats */}
+                                                    <td className="px-4 py-4 whitespace-nowrap align-middle">
+                                                        <ProgressBar value={child.monthly.record_count} max={child.monthly.attendance_count} />
+                                                    </td>
+
+                                                    {/* Monthly Heatmap */}
+                                                    <td className="px-4 py-4 whitespace-nowrap">
+                                                        <MonthlyHeatmap history={child.monthly.daily_status} />
+                                                    </td>
+
+                                                    {/* Yearly Rate (New) */}
+                                                    <td className="px-4 py-4 whitespace-nowrap align-middle">
+                                                        <ProgressBar value={child.yearly.record_count} max={child.yearly.attendance_count} mini={true} />
+                                                    </td>
+
+                                                    {/* Actions (Always Visible) */}
+                                                    <td className="px-4 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                                        <div className="flex items-center justify-end gap-2">
+                                                            <button className="text-slate-400 hover:text-indigo-600 p-2 rounded-full hover:bg-indigo-50 transition-colors" title="履歴">
+                                                                <History className="w-4 h-4" />
+                                                            </button>
+                                                            <button className="bg-white border border-indigo-200 text-indigo-600 hover:bg-indigo-50 hover:border-indigo-300 px-3 py-1.5 rounded-md text-xs font-bold shadow-sm transition-all">
+                                                                作成
+                                                            </button>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            ))
+                                        ) : (
+                                            <tr>
+                                                <td colSpan={7} className="px-6 py-12 text-center text-slate-400">
+                                                    <div className="flex flex-col items-center gap-2">
+                                                        <Filter className="w-8 h-8 text-slate-300" />
+                                                        <span className="text-sm">条件に一致する児童はいません</span>
+                                                        <button
+                                                            onClick={() => { setSearchTerm(''); setWarningOnly(false); setSelectedClass('All'); }}
+                                                            className="text-indigo-600 text-sm hover:underline mt-1"
+                                                        >
+                                                            フィルターをリセット
+                                                        </button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </>
+                )}
             </main>
         </StaffLayout>
     )

--- a/plan/01_implementation-plan.md
+++ b/plan/01_implementation-plan.md
@@ -1,0 +1,72 @@
+# 実装状況サマリとページ別To-Do
+
+## 現状把握（2024-11時点コード調査）
+- 認証: `/login` は Supabase Auth の `signInWithPassword` でログインし、`/api/auth/session` から `getUserSession` を取得するフローが実装済み。ログアウトは `/api/auth/logout` のみ。権限別の画面ガードや施設スコープの切替は未着手。
+- API: Next.js API Routes は認証系2本（session/logout）のみで、業務API（/api/v1 配下想定）は未実装。RLS前提のテナント/施設/クラス絞り込みや共通レスポンスラッパも未整備。
+- 画面: サイトマップ上の主要ページは既存だが、`lib/mock-data.ts` のモック配列を参照する静的UIが中心。Supabaseからの読取/書込、バリデーション、ロールベースUI制御は入っていない。
+- レイアウト/ナビ: `StaffLayout`/`AdminLayout` によりヘッダー/サイドバーは存在するが、ユーザーセッションに紐づいた施設/クラス選択やロール別メニュー出し分けは未実装。
+- 非機能: ログ/レートリミット/MFA/パスワードポリシーなど `docs/00_nonfunctional_requirements_review.md` で求められる対策はまだコードに反映されていない。
+
+## 前提と方針
+- 新規ページは作らず、`docs/05_sitemap.md` にある既存ルート配下で機能実装を行う。
+- Supabaseスキーマは `docs/03_database.md` と `docs/08_database_additions.md` が反映済みである前提。接続設定は完成しているため、UI/ロジックを Supabase 読み書きに置き換える方針とする。
+- 認証・権限は `docs/07_auth_api.md` と `docs/04_api.md`/`docs/09_api_updates_required.md` の役割定義・エンドポイント仕様に従う。
+- RLSとテナント階層（会社→施設→クラス）を前提に、APIとUI双方で facility/class 絞り込みを強制する。
+
+## 実装To-Do（ページ/領域別、既存ページのみ）
+### 認証・セッション共通
+- `/login`:
+  - Supabaseエラーコード別のメッセージ出し分けとパスワードポリシー案内を追加。
+  - ログイン成功時にロール/施設/クラス情報をセッションストレージではなく安全なクライアントストアに保持し、施設切替APIを用意。
+- 共通ミドルウェア/ガード:
+  - サーバーコンポーネントでセッションを検証し、`/admin/*` と 施設職員向け `/dashboard` 以降でロールガードを実装。
+  - `StaffLayout`/`AdminLayout` に施設/クラス選択UIとロール別メニュー出し分けを追加。セッションの current_facility_id を利用。
+
+### APIレイヤー
+- `/api/v1/me`, `/api/v1/facilities`, `/api/v1/classes`, `/api/v1/children`, `/api/v1/tags` などマスタ取得系を実装し、全レスポンスを共通フォーマット化。
+- 記録系: `/api/v1/activities` CRUD と `/api/v1/records`（観察・声・個別記録）を、RLS前提で facility/class 絞り込み＋バリデーション付きで実装。
+- 出席系: `/api/v1/attendance/schedule`・`/attendance/qr`・`/attendance/list` 用の取得/更新APIを用意し、今日の予定/出席/退席イベントを扱う。
+- レポート/保護者系: `docs/08_database_additions.md` に沿って `/api/v1/guardians` と `/api/v1/reports` 系を実装し、`_child_guardian`/`r_report`/`h_report_share` を利用。
+- AI補助: `/api/v1/ai/extract` を実装し、PIIマスキングとレートリミットを組み込む。
+
+### 管理者エリア（/admin）
+- `/admin` TOP: 会社・施設・利用状況の統計を Supabase 集計に置き換え、システムログ要約を表示。
+- `/admin/companies` 一覧/`/admin/companies/new`/`/:id/edit`: CRUD を Supabase 接続化し、`docs/06_database_naming_rules.md` に従ったバリデーションを付与。
+- `/admin/facilities` 一覧/新規/編集: 会社フィルターと施設登録/更新を API 経由で実装。RLS考慮でシステム管理者のみアクセス。
+- `/admin/users`: 会社横断の閲覧一覧を Supabase から取得し、ロール変更・無効化を可能に。MFA設定状態とロックアウト情報も表示。
+- `/admin/logs`: ログイン履歴/監査ログの取得APIを実装し、期間フィルターとテキスト検索を追加。
+
+### ダッシュボード（/dashboard）
+- 本日の出席、未記録児童、未帰所アラートを Supabase の attendance/records データから集計。クイックアクションのリンク先を実データ連携に更新。
+
+### 記録管理（/records）
+- `/records/status`: 本日記録率・未記録児童一覧を Supabase から取得し、クラス/タグフィルターとソートを実装。
+- `/records/activity`: 今日の活動記録の閲覧・保存・写真添付・タグ付け・AI抽出を、`/api/v1/activities` と `/api/v1/ai/extract` を用いたリアルデータに置換。保存後は子ども個別記録への反映も行う。
+- `/records/observation/:childId`: 個別観察記録のCRUDとタグ付け、活動記録とのリンクを Supabase 経由で実装。
+- `/records/voice/:childId`: 子どもの声記録の登録/編集/削除を API 連携し、本人確認のメタ情報も保存。
+
+### 出席管理（/attendance）
+- `/attendance/schedule`: 曜日パターン＋例外を元に今日の予定を表示し、欠席・イレギュラー追加の登録を Supabase 更新に切替。
+- `/attendance/qr`: 子どもごとのチェックインQR発行・スキャン処理を Supabase トリガー/サーバーAPI経由に。重複打刻防止と未登録児の警告を表示。
+- `/attendance/list`: 本日出席中の子ども一覧をリアルタイム更新し、退室操作と未帰所アラートを Supabase データで表示。
+
+### 子ども管理（/children）
+- `/children`: 一覧検索・学年/性別/タグフィルターを Supabase クエリに置換し、施設スコープで絞り込み。
+- `/children/:id`: 基礎情報、最近の記録、観点別記録タブを API 連携。`_child_guardian` の保護者表示を追加。
+- `/children/:id/summary`: 観点別記録数推移グラフを Supabase 集計で描画。
+- `/children/:id/report`: レポート生成・共有履歴保存を `/api/v1/reports` と連携。
+- `/children/new`・`/:id/edit`・`/import`: 登録/更新/CSV取り込みを Supabase 書込に対応し、`docs/06_database_naming_rules.md` の命名・制約を検証。
+
+### 設定（/settings）
+- `/settings/facility`: 施設情報編集フォームを Supabase 更新とバリデーション付きに置換。
+- `/settings/classes`: クラス一覧/作成/編集/削除を API 連携し、担任情報を `_user_class` へ反映。
+- `/settings/schedules`: 子ども別曜日通所設定を閲覧・編集できるフォームを Supabase 読み書きに置換。
+- `/settings/users`: 施設職員の登録・権限設定・有効/無効切替を Supabase と連携し、招待メールの送信ステータスも表示。
+
+### データ管理（/data/export）
+- 期間指定で記録/出席/レポートをCSV出力する API を実装し、ロールチェックとレートリミットを適用。
+
+### セキュリティ/非機能
+- `docs/00_nonfunctional_requirements_review.md` に基づき、パスワードポリシー/MFA/ロックアウト/セッション有効期限を実装。
+- PIIの暗号化・マスキング、AI連携前の匿名化処理、ログの個人情報抑制を適用。
+- 全APIにレートリミットと構造化ログを付与し、Sentry/APMのフックを導入。

--- a/types/attendance.ts
+++ b/types/attendance.ts
@@ -1,0 +1,1 @@
+export type AttendanceStatus = "present" | "absent" | "late" | "not_arrived"


### PR DESCRIPTION
## Summary
- add `GET /api/attendance/list` aligned with the spec in docs/api/15_attendance_list_api.md, including date/class/status/search filters and summary counts for the current day
- update the `/attendance/list` page to call the new API, surface summary tiles, and render class/status/search filters with check-in/out metadata as defined in the attendance list requirements
- introduce a shared `AttendanceStatus` type to keep the API and UI consistent with the allowed status values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693924bb844c8331be5e79cd5f76c810)