### PR TITLE
Fix database error in activity records

### DIFF
--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -50,7 +50,8 @@ export async function GET(request: NextRequest) {
         status,
         created_at,
         updated_at,
-        m_classes!inner (
+        class_id,
+        m_classes (
           id,
           name
         ),
@@ -111,7 +112,7 @@ export async function GET(request: NextRequest) {
       content: activity.content,
       snack: activity.snack,
       photos: activity.photos || [],
-      class_name: activity.m_classes?.name || '',
+      class_name: activity.m_classes?.name || '未設定',
       created_by: activity.m_users?.name || '',
       created_at: activity.created_at,
       is_draft: activity.is_draft || false,


### PR DESCRIPTION
Changed m_classes join from INNER JOIN to LEFT JOIN to support:
- Activities without class_id
- Activities with deleted classes
- Activities with invalid class references

This aligns with the recent fix for children without class assignment.