### PR TITLE
クラスの担任設定機能を実装 (#59)

### DIFF
--- a/app/api/classes/[id]/route.ts
+++ b/app/api/classes/[id]/route.ts
@@ -109,7 +109,7 @@ export async function GET(
 
     const staff =
       staffAssignments?.map((sa: any) => ({
-        user_id: sa.m_users.id,
+        id: sa.m_users.id,
         name: sa.m_users.name,
         role: sa.m_users.role,
         class_role: sa.class_role,
@@ -144,7 +144,7 @@ export async function GET(
         staff: staff,
         children:
           children?.map((child) => ({
-            child_id: child.id,
+            id: child.id,
             name: child.name,
             name_kana: child.name_kana,
             birth_date: child.birth_date,

--- a/app/api/classes/[id]/teachers/[user_id]/route.ts
+++ b/app/api/classes/[id]/teachers/[user_id]/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+
+/**
+ * DELETE /api/classes/:id/teachers/:user_id
+ * クラスから担任を削除
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; user_id: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    // 認証チェック
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // ユーザー情報取得
+    const { data: userData } = await supabase
+      .from('m_users')
+      .select('role, company_id')
+      .eq('id', user.id)
+      .single();
+
+    if (!userData) {
+      return NextResponse.json(
+        { success: false, error: 'User not found' },
+        { status: 404 }
+      );
+    }
+
+    // 権限チェック（staffは更新不可）
+    if (userData.role === 'staff') {
+      return NextResponse.json(
+        { success: false, error: 'Permission denied' },
+        { status: 403 }
+      );
+    }
+
+    const { id: classId, user_id: teacherId } = await params;
+
+    // クラスの存在確認
+    const { data: classData, error: classError } = await supabase
+      .from('m_classes')
+      .select('id, facility_id')
+      .eq('id', classId)
+      .is('deleted_at', null)
+      .single();
+
+    if (classError || !classData) {
+      return NextResponse.json(
+        { success: false, error: 'Class not found' },
+        { status: 404 }
+      );
+    }
+
+    // 施設アクセス権限チェック
+    if (userData.role === 'facility_admin') {
+      const { data: userFacilities } = await supabase
+        .from('_user_facility')
+        .select('facility_id')
+        .eq('user_id', user.id)
+        .eq('is_current', true);
+
+      const facilityIds = userFacilities?.map((uf) => uf.facility_id) || [];
+      if (!facilityIds.includes(classData.facility_id)) {
+        return NextResponse.json(
+          { success: false, error: 'Class not found' },
+          { status: 404 }
+        );
+      }
+    }
+
+    // 担任の割り当てを確認
+    const { data: assignment, error: assignmentError } = await supabase
+      .from('_user_class')
+      .select('id')
+      .eq('user_id', teacherId)
+      .eq('class_id', classId)
+      .eq('is_current', true)
+      .single();
+
+    if (assignmentError || !assignment) {
+      return NextResponse.json(
+        { success: false, error: 'Teacher assignment not found' },
+        { status: 404 }
+      );
+    }
+
+    // 担任を解除（履歴として保持するため、is_currentをfalseにしてend_dateを設定）
+    const today = new Date().toISOString().split('T')[0];
+    const { error: updateError } = await supabase
+      .from('_user_class')
+      .update({
+        is_current: false,
+        end_date: today,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', assignment.id);
+
+    if (updateError) {
+      throw updateError;
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        user_id: teacherId,
+        class_id: classId,
+        removed_at: today,
+      },
+      message: '担任を解除しました',
+    });
+  } catch (error) {
+    console.error('Error removing teacher from class:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Internal Server Error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/classes/[id]/teachers/route.ts
+++ b/app/api/classes/[id]/teachers/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+
+/**
+ * POST /api/classes/:id/teachers
+ * クラスに担任を追加
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    // 認証チェック
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // ユーザー情報取得
+    const { data: userData } = await supabase
+      .from('m_users')
+      .select('role, company_id')
+      .eq('id', user.id)
+      .single();
+
+    if (!userData) {
+      return NextResponse.json(
+        { success: false, error: 'User not found' },
+        { status: 404 }
+      );
+    }
+
+    // 権限チェック（staffは更新不可）
+    if (userData.role === 'staff') {
+      return NextResponse.json(
+        { success: false, error: 'Permission denied' },
+        { status: 403 }
+      );
+    }
+
+    const { id: classId } = await params;
+
+    // クラスの存在確認
+    const { data: classData, error: classError } = await supabase
+      .from('m_classes')
+      .select('id, facility_id')
+      .eq('id', classId)
+      .is('deleted_at', null)
+      .single();
+
+    if (classError || !classData) {
+      return NextResponse.json(
+        { success: false, error: 'Class not found' },
+        { status: 404 }
+      );
+    }
+
+    // 施設アクセス権限チェック
+    if (userData.role === 'facility_admin') {
+      const { data: userFacilities } = await supabase
+        .from('_user_facility')
+        .select('facility_id')
+        .eq('user_id', user.id)
+        .eq('is_current', true);
+
+      const facilityIds = userFacilities?.map((uf) => uf.facility_id) || [];
+      if (!facilityIds.includes(classData.facility_id)) {
+        return NextResponse.json(
+          { success: false, error: 'Class not found' },
+          { status: 404 }
+        );
+      }
+    }
+
+    const body = await request.json();
+    const { user_id, class_role = 'main' } = body;
+
+    if (!user_id) {
+      return NextResponse.json(
+        { success: false, error: 'user_id is required' },
+        { status: 400 }
+      );
+    }
+
+    // 追加する職員が存在するか確認
+    const { data: teacherData, error: teacherError } = await supabase
+      .from('m_users')
+      .select('id, name, role')
+      .eq('id', user_id)
+      .is('deleted_at', null)
+      .single();
+
+    if (teacherError || !teacherData) {
+      return NextResponse.json(
+        { success: false, error: 'Teacher not found' },
+        { status: 404 }
+      );
+    }
+
+    // すでに担任として登録されていないか確認
+    const { data: existingAssignment } = await supabase
+      .from('_user_class')
+      .select('id')
+      .eq('user_id', user_id)
+      .eq('class_id', classId)
+      .eq('is_current', true)
+      .single();
+
+    if (existingAssignment) {
+      return NextResponse.json(
+        { success: false, error: 'Teacher already assigned to this class' },
+        { status: 400 }
+      );
+    }
+
+    // 担任を追加
+    const { data: newAssignment, error: insertError } = await supabase
+      .from('_user_class')
+      .insert({
+        user_id,
+        class_id: classId,
+        class_role,
+        start_date: new Date().toISOString().split('T')[0],
+        is_current: true,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      throw insertError;
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        assignment_id: newAssignment.id,
+        user_id: teacherData.id,
+        name: teacherData.name,
+        role: teacherData.role,
+        class_role,
+      },
+      message: '担任を追加しました',
+    });
+  } catch (error) {
+    console.error('Error adding teacher to class:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Internal Server Error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## 変更内容
- クラス担任の追加・削除機能を実装
- モックから実際のDB連携に変更

## 実装詳細

### APIエンドポイント
- `POST /api/classes/:id/teachers` - 担任追加
- `DELETE /api/classes/:id/teachers/:user_id` - 担任削除
- `GET /api/classes/:id` のレスポンス修正（idフィールドの統一）

### データベース
- `_user_class` テーブルを使用した担任管理
- `class_role` カラムで役割を管理（main/sub/assistant）
- `is_current` カラムで現在の担任を判定
- 担任解除時は履歴として保持（is_current=false, end_date設定）

### フロントエンド
- Teacher型を `is_main` から `class_role` に変更
- 担任追加時に役割を選択可能（主担任/副担任/補助）
- 担任リストで役割に応じた色分け表示
- API呼び出しでデータベースと連携

## 関連Issue
Fixes #59