### PR TITLE
子どもの個人登録に学校選択機能を追加

### DIFF
--- a/app/api/children/[id]/route.ts
+++ b/app/api/children/[id]/route.ts
@@ -79,6 +79,7 @@ export async function GET(
           gender: childData.gender,
           birth_date: childData.birth_date,
           photo_url: childData.photo_url,
+          school_id: childData.school_id,
         },
         affiliation: {
           enrollment_status: childData.enrollment_status,
@@ -168,6 +169,7 @@ export async function PUT(
       if (basic_info.nickname !== undefined) updateData.nickname = basic_info.nickname;
       if (basic_info.gender !== undefined) updateData.gender = basic_info.gender;
       if (basic_info.birth_date !== undefined) updateData.birth_date = basic_info.birth_date;
+      if (basic_info.school_id !== undefined) updateData.school_id = basic_info.school_id;
     }
 
     if (affiliation) {

--- a/app/api/children/route.ts
+++ b/app/api/children/route.ts
@@ -318,6 +318,7 @@ export async function POST(request: NextRequest) {
       .from('m_children')
       .insert({
         facility_id,
+        school_id: basic_info.school_id || null,
         family_name: basic_info.family_name,
         given_name: basic_info.given_name,
         family_name_kana: basic_info.family_name_kana || '',


### PR DESCRIPTION
## 変更内容

### フロントエンド (components/children/ChildForm.tsx)
- 学校選択フィールドを「基本情報」セクションに追加
- 学校一覧を /api/schools から取得
- formData に school_id を追加
- 学校選択を必須項目として検証を追加

### バックエンド API
- POST /api/children: 子ども登録時に school_id を保存
- PUT /api/children/[id]: 子ども更新時に school_id を更新
- GET /api/children/[id]: 子ども詳細取得時に school_id を返却

### データベース
- m_children.school_id を使用（既存のカラム）

## 関連Issue
#28