### PR TITLE
施設詳細APIを会社単位のアクセスに変更

### DIFF
--- a/app/api/facilities/[facility_id]/route.ts
+++ b/app/api/facilities/[facility_id]/route.ts
@@ -71,36 +71,15 @@ export async function GET(
       );
     }
 
-    // 権限チェック
+    // 権限チェック（設定ページでは会社が同じであればアクセス可能）
     if (
       userData.role !== 'site_admin' &&
-      userData.role === 'company_admin' &&
       facility.company_id !== userData.company_id
     ) {
       return NextResponse.json(
         { success: false, error: 'Access denied' },
         { status: 404 }
       );
-    }
-
-    if (
-      userData.role === 'facility_admin' ||
-      userData.role === 'staff'
-    ) {
-      const { data: userFacility } = await supabase
-        .from('_user_facility')
-        .select('facility_id')
-        .eq('user_id', user.id)
-        .eq('facility_id', facilityId)
-        .eq('is_current', true)
-        .single();
-
-      if (!userFacility) {
-        return NextResponse.json(
-          { success: false, error: 'Access denied' },
-          { status: 404 }
-        );
-      }
     }
 
     // 統計情報取得
@@ -208,9 +187,9 @@ export async function PUT(
       );
     }
 
-    // 権限チェック
+    // 権限チェック（設定ページでは会社が同じであればアクセス可能）
     if (
-      userData.role === 'company_admin' &&
+      userData.role !== 'site_admin' &&
       facility.company_id !== userData.company_id
     ) {
       return NextResponse.json(
@@ -219,23 +198,7 @@ export async function PUT(
       );
     }
 
-    if (userData.role === 'facility_admin') {
-      const { data: userFacility } = await supabase
-        .from('_user_facility')
-        .select('facility_id')
-        .eq('user_id', user.id)
-        .eq('facility_id', facilityId)
-        .eq('is_current', true)
-        .single();
-
-      if (!userFacility) {
-        return NextResponse.json(
-          { success: false, error: 'Access denied' },
-          { status: 404 }
-        );
-      }
-    }
-
+    // staff は編集不可
     if (userData.role === 'staff') {
       return NextResponse.json(
         { success: false, error: 'Permission denied' },


### PR DESCRIPTION
修正内容:
- GET: is_current フィルタを削除し、会社IDで権限チェック
- PUT: is_current フィルタを削除し、会社IDで権限チェック
- 全ロールで同じ会社の施設であれば閲覧・編集可能に
- staff は引き続き編集不可

変更ファイル:
- app/api/facilities/[facility_id]/route.ts (line 74-83, 190-207)