### PR TITLE
詳細ページでのサイドメニューの表示

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -169,7 +169,7 @@ export function Sidebar({ type, isOpen = false, onClose }: SidebarProps) {
                             href={child.href}
                             className={cn(
                               "block rounded-lg px-3 py-2 text-sm text-sidebar-foreground hover:bg-sidebar-accent",
-                              pathname === child.href && "bg-sidebar-accent font-medium",
+                              isActive(child.href) && "bg-sidebar-accent font-medium",
                             )}
                           >
                             {child.label}
@@ -184,7 +184,7 @@ export function Sidebar({ type, isOpen = false, onClose }: SidebarProps) {
                   href={item.href}
                   className={cn(
                     "flex items-center gap-3 rounded-lg px-3 py-2 text-sm text-sidebar-foreground hover:bg-sidebar-accent",
-                    pathname === item.href && "bg-sidebar-accent font-medium",
+                    isActive(item.href) && "bg-sidebar-accent font-medium",
                   )}
                 >
                   {item.icon}


### PR DESCRIPTION
詳細ページでもサイドメニューのアクティブ状態（色）を維持するように修正

変更内容：
- 子メニューと親メニューのアクティブ判定を完全一致からisActive関数に変更
- isActive関数により、パスの前方一致でもアクティブ状態を判定
- 例: /settings/facility/123 のような詳細ページでも /settings/facility メニューがハイライトされる
#56
