### PR TITLE
学校ごとのスケジュール削除の際はデータごと削除

### DIFF
--- a/app/api/schools/[school_id]/schedules/[schedule_id]/route.ts
+++ b/app/api/schools/[school_id]/schedules/[schedule_id]/route.ts
@@ -248,16 +248,12 @@ export async function DELETE(
       }
     }
 
-    const deletedAt = new Date().toISOString();
-
-    // スケジュール削除（ソフトデリート）
+    // スケジュール削除（物理削除）
     const { error: deleteError } = await supabase
       .from('s_school_schedules')
-      .update({
-        deleted_at: deletedAt,
-        updated_at: deletedAt,
-      })
-      .eq('id', schedule_id);
+      .delete()
+      .eq('id', schedule_id)
+      .eq('school_id', school_id);
 
     if (deleteError) {
       throw deleteError;
@@ -267,7 +263,6 @@ export async function DELETE(
       success: true,
       data: {
         schedule_id: schedule_id,
-        deleted_at: deletedAt,
       },
       message: 'スケジュールを削除しました',
     });


### PR DESCRIPTION
## Summary
- Update `/api/schools/:school_id/schedules/:schedule_id` deletion to remove schedule rows instead of only setting `deleted_at`, keeping the behavior aligned with the schedule settings API surface in `docs/api/26_schedule_settings_api.md` and the requested hard-delete workflow.
- Scope the deletion to both schedule and school IDs to ensure the correct record is removed.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ed95edb0833187c6531f7ca8eb9b)