### PR TITLE
学校の年を±できる入力項目

### DIFF
--- a/app/api/children/[id]/route.ts
+++ b/app/api/children/[id]/route.ts
@@ -81,6 +81,7 @@ export async function GET(
           birth_date: childData.birth_date,
           photo_url: childData.photo_url,
           school_id: childData.school_id,
+          grade_add: childData.grade_add || 0,
         },
         affiliation: {
           enrollment_status: childData.enrollment_status,

--- a/app/api/children/save/route.ts
+++ b/app/api/children/save/route.ts
@@ -13,6 +13,7 @@ interface ChildPayload {
     gender?: string;
     birth_date?: string;
     school_id?: string | null;
+    grade_add?: number;
   };
   affiliation?: {
     enrollment_status?: string;
@@ -75,6 +76,7 @@ async function saveChild(
     nickname: basic_info.nickname || null,
     gender: basic_info.gender || 'other',
     birth_date: basic_info.birth_date,
+    grade_add: basic_info.grade_add !== undefined ? basic_info.grade_add : 0,
     enrollment_status: affiliation.enrollment_status || 'enrolled',
     enrollment_type: affiliation.enrollment_type || 'regular',
     enrolled_at: affiliation.enrolled_at ? new Date(affiliation.enrolled_at).toISOString() : new Date().toISOString(),

--- a/components/children/ChildForm.tsx
+++ b/components/children/ChildForm.tsx
@@ -158,6 +158,7 @@ export default function ChildForm({ mode, childId, onSuccess }: ChildFormProps) 
     birth_day: '',
     birth_date: '', // 編集モード用
     school_id: '',
+    grade_add: 0,
 
     // 所属・契約
     enrollment_status: 'enrolled' as 'enrolled' | 'withdrawn' | 'suspended',
@@ -252,6 +253,7 @@ export default function ChildForm({ mode, childId, onSuccess }: ChildFormProps) 
             birth_day: day,
             birth_date: birthDate,
             school_id: data.basic_info?.school_id || '',
+            grade_add: data.basic_info?.grade_add || 0,
             enrollment_status: data.affiliation?.enrollment_status || 'enrolled',
             enrollment_type: data.affiliation?.enrollment_type || 'regular',
             enrolled_at: data.affiliation?.enrolled_at ? data.affiliation.enrolled_at.split('T')[0] : '',
@@ -382,6 +384,7 @@ export default function ChildForm({ mode, childId, onSuccess }: ChildFormProps) 
           gender: formData.gender,
           birth_date: birthDate,
           school_id: formData.school_id || null,
+          grade_add: formData.grade_add,
         },
         affiliation: {
           enrollment_status: formData.enrollment_status,
@@ -625,6 +628,23 @@ export default function ChildForm({ mode, childId, onSuccess }: ChildFormProps) 
                         ))}
                       </Select>
                       <p className="text-xs text-slate-400 mt-1">※学校が登録されていない場合は、先に学校マスタから登録してください</p>
+                    </FieldGroup>
+
+                    <FieldGroup label="学年調整" className="sm:col-span-2">
+                      <div className="flex items-center gap-4">
+                        <Select
+                          value={formData.grade_add.toString()}
+                          onChange={(e: any) => setFormData({ ...formData, grade_add: parseInt(e.target.value) })}
+                          className="w-48"
+                        >
+                          <option value="-2">-2年（2学年下）</option>
+                          <option value="-1">-1年（1学年下）</option>
+                          <option value="0">調整なし（標準）</option>
+                          <option value="1">+1年（1学年上）</option>
+                          <option value="2">+2年（2学年上）</option>
+                        </Select>
+                        <p className="text-xs text-slate-500">留年・飛び級などで学年を調整する場合に設定します</p>
+                      </div>
                     </FieldGroup>
                   </div>
                 </div>


### PR DESCRIPTION
- Add grade_add field to ChildForm component state
- Add grade_add UI field with -2 to +2 year adjustment options
- Update API save endpoint to handle grade_add field
- Update API GET endpoint to return grade_add in basic_info
- Support editing mode to load and save grade_add value

This allows staff to adjust student grade levels for cases like retention or grade advancement.

#69
