### PR TITLE
Switch activity AI generation to Gemini

### DIFF
--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { getUserSession } from '@/lib/auth/session';
-import { ChatOpenAI } from '@langchain/openai';
 import { PromptTemplate } from '@langchain/core/prompts';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 
 export async function GET(request: NextRequest) {
   try {
@@ -191,20 +191,21 @@ export async function POST(request: NextRequest) {
 
     // LangChainで個別記録を生成（簡素化版：入力をそのまま返す）
     const observations = [];
+    const aiErrors: { child_id: string; message: string }[] = [];
     if (child_ids && child_ids.length > 0) {
       // Initialize LangChain
-      const model = new ChatOpenAI({
-        modelName: 'gpt-4o-mini',
-        temperature: 0.7,
-        openAIApiKey: process.env.OPENAI_API_KEY,
+      const model = new ChatGoogleGenerativeAI({
+        model: 'gemini-1.5-flash',
+        temperature: 0,
+        apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
       });
 
       // Simple prompt that returns the input as-is
-      const template = `以下の活動内容から、児童の様子を記録してください。
+      const template = `次のテキストを一切加工せずにそのまま返してください。挨拶や説明を付け加えないでください。
 
-活動内容: {content}
+テキスト: {content}
 
-記録:`;
+返却:`;
 
       const prompt = PromptTemplate.fromTemplate(template);
       const chain = prompt.pipe(model);
@@ -213,7 +214,13 @@ export async function POST(request: NextRequest) {
         try {
           // Call LangChain (minimal implementation)
           const result = await chain.invoke({ content });
-          const observationContent = result.content || content;
+          const resultContent = Array.isArray(result.content)
+            ? result.content.join('')
+            : result.content;
+          const observationContent =
+            typeof resultContent === 'string' && resultContent.trim().length > 0
+              ? resultContent
+              : content;
 
           // Insert observation record
           const { error: obsError } = await supabase
@@ -229,9 +236,27 @@ export async function POST(request: NextRequest) {
 
           if (!obsError) {
             observations.push({ child_id, content: observationContent });
+          } else {
+            aiErrors.push({ child_id, message: 'Failed to insert observation' });
           }
         } catch (error) {
           console.error('LangChain error for child:', child_id, error);
+          aiErrors.push({ child_id, message: 'AI generation failed, used fallback text' });
+
+          const { error: obsError } = await supabase
+            .from('r_observation')
+            .insert({
+              child_id,
+              facility_id,
+              activity_id: activity.id,
+              recorded_at: new Date().toISOString(),
+              content,
+              created_by: session.user.id,
+            });
+
+          if (!obsError) {
+            observations.push({ child_id, content });
+          }
           // Continue with next child even if one fails
         }
       }
@@ -246,6 +271,7 @@ export async function POST(request: NextRequest) {
         content: activity.content,
         observations_created: observations.length,
         observations,
+        ai_errors: aiErrors,
       },
     });
 

--- a/app/records/activity/page.tsx
+++ b/app/records/activity/page.tsx
@@ -130,7 +130,7 @@ export default function ActivityRecordPage() {
               <div className="flex items-center gap-2">
                 <span className="text-[10px] bg-indigo-50 text-indigo-600 px-2 py-1 rounded border border-indigo-100 font-bold flex items-center gap-1">
                   <Sparkles className="w-3 h-3" />
-                  Gemini Pro 搭載
+                  Gemini 1.5 Flash 搭載
                 </span>
                 <Button variant="ghost" size="sm" className="text-sm font-bold">
                   下書き保存
@@ -181,7 +181,7 @@ export default function ActivityRecordPage() {
                 <Textarea
                   value={activityContent}
                   onChange={(e) => setActivityContent(e.target.value)}
-                  placeholder="手入力するか、上の「AI音声で下書き」ボタンを押して喋ってください。&#10;Geminiが綺麗な文章に整えます。"
+                  placeholder="手入力するか、上の「AI音声で下書き」ボタンを押して喋ってください。&#10;Gemini 1.5 Flash が綺麗な文章に整えます。"
                   className="min-h-64 text-base leading-relaxed resize-none"
                 />
                 
@@ -191,7 +191,7 @@ export default function ActivityRecordPage() {
                     <div className="text-center">
                       <div className="w-8 h-8 border-4 border-indigo-200 border-t-indigo-600 rounded-full animate-spin mx-auto mb-2"></div>
                       <p className="text-xs font-bold text-indigo-600 animate-pulse">
-                        Geminiが文章を整えています...
+                        Gemini 1.5 Flash が文章を整えています...
                       </p>
                     </div>
                   </div>
@@ -237,7 +237,7 @@ export default function ActivityRecordPage() {
               <div className="bg-indigo-50 border-b border-indigo-100 p-4 flex justify-between items-center">
                 <h2 className="font-bold text-gray-800 flex items-center gap-2">
                   <Sparkles className="w-5 h-5 text-indigo-600" />
-                  AI解析結果 (Gemini)
+                  AI解析結果 (Gemini 1.5 Flash)
                 </h2>
                 <Button
                   variant="ghost"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@langchain/google-genai": "^0.1.1",
     "@langchain/core": "^1.1.4",
     "@langchain/openai": "^1.1.3",
     "@radix-ui/react-accordion": "1.2.2",


### PR DESCRIPTION
## Summary
- Swapped the activity observation LangChain client to Gemini 1.5 Flash with an echo prompt and structured fallback so AI-assisted individual record creation stays predictable and still returns text when generation fails, aligning with the goal of automated individual records.【F:docs/01_requirements.md†L55-L60】
- Surfaced Gemini branding in the activity record UI so loading states and badges match the configured model name.【F:app/records/activity/page.tsx†L128-L241】
- Added the Google Generative AI client dependency required for the new backend model.【F:package.json†L11-L71】

## Testing
- Not run (environment limitation)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940f9e939b483319c7fc5cc933da15d)