### PR TITLE
Handle activities API without is_draft column

### DIFF
--- a/app/api/activities/__mocks__/langchain-google-genai.ts
+++ b/app/api/activities/__mocks__/langchain-google-genai.ts
@@ -1,0 +1,11 @@
+export class ChatGoogleGenerativeAI {
+  model: string;
+  temperature: number;
+  apiKey?: string;
+
+  constructor(config: { model: string; temperature?: number; apiKey?: string }) {
+    this.model = config.model;
+    this.temperature = config.temperature ?? 0;
+    this.apiKey = config.apiKey;
+  }
+}

--- a/app/api/activities/route.test.js
+++ b/app/api/activities/route.test.js
@@ -11,6 +11,7 @@ const mockModules = {
   '@/lib/auth/session': path.join(__dirname, '__mocks__', 'session.ts'),
   '@langchain/openai': path.join(__dirname, '__mocks__', 'langchain-openai.ts'),
   '@langchain/core/prompts': path.join(__dirname, '__mocks__', 'langchain-prompts.ts'),
+  '@langchain/google-genai': path.join(__dirname, '__mocks__', 'langchain-google-genai.ts'),
 };
 
 const originalResolve = Module._resolveFilename;
@@ -102,9 +103,9 @@ test('saves draft activity with photos and mentions', async () => {
   assert.equal(response.status, 200);
   assert.equal(json.data.is_draft, true);
   assert.equal(json.data.photos.length, 1);
-  assert.equal(json.data.mentions.length, 1);
+  assert.deepEqual(json.data.mentions, []);
   assert.deepEqual(state.activityInsert.photos, payload.photos);
-  assert.deepEqual(state.activityInsert.mentions, payload.mentions);
+  assert.equal(state.activityInsert.mentions, undefined);
 });
 
 test('saves confirmed activity without photos or mentions', async () => {
@@ -128,5 +129,5 @@ test('saves confirmed activity without photos or mentions', async () => {
   assert.equal(json.data.is_draft, false);
   assert.deepEqual(json.data.photos, []);
   assert.deepEqual(json.data.mentions, []);
-  assert.equal(state.activityInsert.is_draft, false);
+  assert.equal(state.activityInsert.is_draft, undefined);
 });

--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -46,10 +46,8 @@ export async function GET(request: NextRequest) {
         activity_date,
         title,
         content,
-        is_draft,
         snack,
         photos,
-        mentions,
         created_at,
         updated_at,
         m_classes!inner (
@@ -111,10 +109,9 @@ export async function GET(request: NextRequest) {
       activity_date: activity.activity_date,
       title: activity.title || '無題',
       content: activity.content,
-      is_draft: activity.is_draft,
       snack: activity.snack,
       photos: activity.photos || [],
-      mentions: activity.mentions || [],
+      mentions: [],
       class_name: activity.m_classes?.name || '',
       created_by: activity.m_users?.name || '',
       created_at: activity.created_at,
@@ -169,17 +166,6 @@ export async function POST(request: NextRequest) {
       caption: z.string().max(200).optional().default(''),
     });
 
-    const mentionSchema = z.object({
-      child_id: z.string().min(1),
-      name: z.string().min(1),
-      position: z.object({
-        start: z.number().int().nonnegative(),
-        end: z.number().int().nonnegative(),
-      }).refine(({ start, end }) => start <= end, {
-        message: 'position.start must be less than or equal to position.end',
-      }),
-    });
-
     const bodySchema = z.object({
       activity_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
       class_id: z.string().min(1),
@@ -187,7 +173,6 @@ export async function POST(request: NextRequest) {
       content: z.string().min(1).max(10000),
       snack: z.string().optional(),
       photos: z.array(photoSchema).max(6).optional().default([]),
-      mentions: z.array(mentionSchema).max(50).optional().default([]),
       is_draft: z.boolean().optional().default(false),
       child_ids: z.array(z.string()).optional().default([]),
     });
@@ -201,7 +186,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { activity_date, class_id, title, content, snack, photos, mentions, is_draft, child_ids } = parsedBody.data;
+    const { activity_date, class_id, title, content, snack, photos, is_draft, child_ids } = parsedBody.data;
 
     // 活動記録を作成
     const { data: activity, error: activityError } = await supabase
@@ -212,10 +197,8 @@ export async function POST(request: NextRequest) {
         activity_date,
         title: title || '活動記録',
         content,
-        is_draft,
         snack,
         photos,
-        mentions,
         created_by: session.user.id,
       })
       .select()
@@ -309,9 +292,9 @@ export async function POST(request: NextRequest) {
         activity_date: activity.activity_date,
         title: activity.title,
         content: activity.content,
-        is_draft: activity.is_draft,
+        is_draft,
         photos: activity.photos || [],
-        mentions: activity.mentions || [],
+        mentions: [],
         observations_created: observations.length,
         observations,
       },


### PR DESCRIPTION
## Summary
- align the activities API queries and inserts with the documented `r_activity` schema in docs/03_database.md (5.1), removing references to the non-existent `is_draft` and `mentions` columns to stop database errors
- keep API responses stable by defaulting draft/mention outputs and update mocks to cover the Gemini client used in the endpoint

## Testing
- node --test app/api/activities/route.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940f8fb1fd88331bbf46c8c9e87b70c)