### PR TITLE
Rename activity record save button

### DIFF
--- a/app/records/activity/page.tsx
+++ b/app/records/activity/page.tsx
@@ -163,7 +163,7 @@ export default function ActivityRecordPage() {
                   Gemini Pro 搭載
                 </span>
                 <Button variant="ghost" size="sm" className="text-sm font-bold">
-                  下書き保存
+                  保存
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Rename the activity record form action button from "下書き保存" to "保存" to align with REC-01 activity record input workflow (docs/01_requirements.md lines 177-184).

## Testing
- Not run (UI text only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69420f50a40c8331a0ec0fc99c878aeb)