### PR TITLE
ビルドエラーの修正

### DIFF
--- a/app/records/activity/page.tsx
+++ b/app/records/activity/page.tsx
@@ -73,6 +73,9 @@ export default function ActivityRecordPage() {
   >([])
   const [classError, setClassError] = useState<string | null>(null)
   const [classChildren, setClassChildren] = useState<MentionSuggestion[]>([])
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveMessage, setSaveMessage] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
@@ -88,19 +91,22 @@ export default function ActivityRecordPage() {
           throw new Error(result.error || 'クラスの取得に失敗しました')
         }
 
-      const classes = result.data?.classes || []
-      setClassOptions(classes)
+        const classes = result.data?.classes || []
+        setClassOptions(classes)
 
-      if (classes.length > 0 && !selectedClass) {
-        setSelectedClass(classes[0].class_id)
+        if (classes.length > 0) {
+          setSelectedClass((prev) => prev || classes[0].class_id)
+        }
+      } catch (err) {
+        console.error('Failed to fetch classes:', err)
+        setClassError(err instanceof Error ? err.message : 'クラスの取得に失敗しました')
+      } finally {
+        setIsLoadingClasses(false)
       }
-    } catch (err) {
-      console.error('Failed to fetch classes:', err)
-      setClassError(err instanceof Error ? err.message : 'クラスの取得に失敗しました')
-    } finally {
-      setIsLoadingClasses(false)
     }
-  }, [selectedClass])
+
+    fetchClasses()
+  }, [])
 
   const fetchActivities = useCallback(async () => {
     try {
@@ -123,10 +129,11 @@ export default function ActivityRecordPage() {
     } finally {
       setLoading(false)
     }
-
-    fetchClasses()
-    fetchActivities()
   }, [])
+
+  useEffect(() => {
+    fetchActivities()
+  }, [fetchActivities])
 
   const toHiragana = (text: string) =>
     text.replace(/[ァ-ン]/g, (char) =>


### PR DESCRIPTION
## Summary
- Initialize class fetching and activity loading hooks correctly so the 活動記録 input flow renders without parse errors, aligning with the record-entry scope in docs/01_requirements.md (§3.1 and §5.3 REC-01/REC-02).
- Add missing saving-related state to the activity page to keep the activity record form behavior consistent with the documented recording requirements.

## Testing
- npm run lint *(fails: repository lacks eslint.config.js per ESLint 9 migration notice)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942568728f08331bd1c60e3ca2a341e)