### PR TITLE
Optimize dashboard attendance lookups

### DIFF
--- a/app/api/dashboard/summary/utils.ts
+++ b/app/api/dashboard/summary/utils.ts
@@ -1,0 +1,104 @@
+export type AttendanceLogsIndex = Record<string, {
+  activeLog: any | null;
+  latestClosedLog: any | null;
+}>;
+
+export type ObservationSummary = Record<string, {
+  lastRecordDate: string | null;
+  weeklyCount: number;
+}>;
+
+export type AttendanceListItem = {
+  child_id: string;
+  name: string;
+  kana: string;
+  class_id: string | null;
+  class_name: string;
+  age_group: string;
+  grade: number | null;
+  grade_label: string;
+  photo_url: string | null;
+  status: 'checked_in' | 'checked_out' | 'absent';
+  is_scheduled_today: boolean;
+  scheduled_start_time: string | null;
+  scheduled_end_time: string | null;
+  actual_in_time: string | null;
+  actual_out_time: string | null;
+  guardian_phone: string;
+  last_record_date: string | null;
+  weekly_record_count: number;
+};
+
+export const buildAttendanceLogsIndex = (attendanceLogs: any[]): AttendanceLogsIndex => {
+  return attendanceLogs.reduce((acc: AttendanceLogsIndex, log: any) => {
+    const childId = log.child_id;
+    const currentEntry = acc[childId] || { activeLog: null, latestClosedLog: null };
+    const checkedInAt = new Date(log.checked_in_at).getTime();
+
+    if (!log.checked_out_at) {
+      const currentActiveTime = currentEntry.activeLog ? new Date(currentEntry.activeLog.checked_in_at).getTime() : -Infinity;
+      if (checkedInAt > currentActiveTime) {
+        currentEntry.activeLog = log;
+      }
+    } else {
+      const currentClosedTime = currentEntry.latestClosedLog
+        ? new Date(currentEntry.latestClosedLog.checked_in_at).getTime()
+        : -Infinity;
+      if (checkedInAt > currentClosedTime) {
+        currentEntry.latestClosedLog = log;
+      }
+    }
+
+    acc[childId] = currentEntry;
+    return acc;
+  }, {});
+};
+
+export const buildObservationSummary = (observations: any[]): ObservationSummary => {
+  return observations.reduce((acc: ObservationSummary, obs: any) => {
+    const childId = obs.child_id;
+    const current = acc[childId] || { lastRecordDate: null, weeklyCount: 0 };
+    current.weeklyCount += 1;
+    if (!current.lastRecordDate || obs.observation_date > current.lastRecordDate) {
+      current.lastRecordDate = obs.observation_date;
+    }
+    acc[childId] = current;
+    return acc;
+  }, {});
+};
+
+export const determineStatus = (
+  activeLog: any | null,
+  latestClosedLog: any | null,
+  dailyRecordStatus?: string
+): AttendanceListItem['status'] => {
+  if (activeLog) {
+    return 'checked_in';
+  }
+  if (latestClosedLog) {
+    return 'checked_out';
+  }
+  if (!activeLog && !latestClosedLog && dailyRecordStatus === 'absent') {
+    return 'absent';
+  }
+  return 'absent';
+};
+
+export const calculateKpis = (attendanceList: AttendanceListItem[]) => {
+  return attendanceList.reduce(
+    (acc, child) => {
+      if (child.is_scheduled_today) {
+        acc.scheduledToday += 1;
+      }
+      if (child.status === 'checked_in') {
+        acc.presentNow += 1;
+      } else if (child.status === 'checked_out') {
+        acc.checkedOut += 1;
+      } else if (child.is_scheduled_today && child.status === 'absent') {
+        acc.notArrived += 1;
+      }
+      return acc;
+    },
+    { scheduledToday: 0, presentNow: 0, notArrived: 0, checkedOut: 0 }
+  );
+};

--- a/tests/status-kpi.test.ts
+++ b/tests/status-kpi.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+import { calculateKpis, determineStatus } from '../app/api/dashboard/summary/utils';
+
+const baseLog = {
+  child_id: 'child-1',
+  checked_in_at: '2024-05-01T09:00:00Z',
+  checked_out_at: null as string | null,
+};
+
+const closedLog = {
+  ...baseLog,
+  child_id: 'child-2',
+  checked_out_at: '2024-05-01T12:00:00Z',
+};
+
+type MinimalAttendanceListItem = Pick<
+  Parameters<typeof calculateKpis>[0][number],
+  'status' | 'is_scheduled_today'
+>;
+
+(() => {
+  assert.strictEqual(determineStatus(baseLog, null, 'scheduled'), 'checked_in');
+  assert.strictEqual(determineStatus(null, closedLog, 'scheduled'), 'checked_out');
+  assert.strictEqual(determineStatus(null, null, 'absent'), 'absent');
+})();
+
+(() => {
+  const attendanceList: MinimalAttendanceListItem[] = [
+    { status: 'checked_in', is_scheduled_today: true },
+    { status: 'checked_out', is_scheduled_today: true },
+    { status: 'absent', is_scheduled_today: true },
+    { status: 'absent', is_scheduled_today: false },
+  ];
+
+  const kpis = calculateKpis(attendanceList as Parameters<typeof calculateKpis>[0]);
+  assert.deepStrictEqual(kpis, {
+    scheduledToday: 3,
+    presentNow: 1,
+    notArrived: 1,
+    checkedOut: 1,
+  });
+})();
+
+console.log('status and KPI calculations remain consistent');

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": ".tmp-tests"
+  },
+  "include": [
+    "tests/**/*.ts",
+    "app/api/dashboard/summary/route.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- Precompute per-child attendance schedules, logs, and observation summaries to remove repeated filtering while keeping dashboard outputs aligned with the staff dashboard specs in docs/01_requirements.md.
- Centralize status and KPI calculations for the dashboard summary API so the logic is reused consistently.
- Add a simple test build configuration and unit coverage to confirm status and KPI expectations remain unchanged.

## Testing
- pnpm exec tsc -p tsconfig.test.json --pretty false
- node .tmp-tests/tests/status-kpi.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694391dac7fc8331a7249eb0d2743c2e)