### PR TITLE
Update children new page label to 児童登録

### DIFF
--- a/app/children/new/page.tsx
+++ b/app/children/new/page.tsx
@@ -4,7 +4,7 @@ import ChildForm from "@/components/children/ChildForm";
 
 export default function ChildRegistrationForm() {
   return (
-    <StaffLayout title="園児登録">
+    <StaffLayout title="児童登録">
       <ChildForm mode="new" />
     </StaffLayout>
   );


### PR DESCRIPTION
## Summary
- update the staff layout title on `/children/new` from 「園児登録」 to 「児童登録」 to match requested wording.

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440317486483318eca877cea33b020)