### PR TITLE
施設の保存処理でエラーが発生する。

### DIFF
--- a/app/api/facilities/route.ts
+++ b/app/api/facilities/route.ts
@@ -187,25 +187,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 施設作成
+    // 施設作成（現行スキーマに合わせて不要カラムは送信しない）
     const { data: newFacility, error: createError } = await supabase
       .from('m_facilities')
       .insert({
         company_id: userData.company_id,
         name: body.name,
+        name_kana: body.name_kana ?? null,
+        postal_code: body.postal_code ?? null,
         address: body.address,
         phone: body.phone,
-        email: body.email,
-        postal_code: body.postal_code,
-        fax: body.fax,
-        website: body.website,
-        director_name: body.director_name,
-        capacity: body.capacity,
-        established_date: body.established_date,
-        license_number: body.license_number,
-        opening_time: body.opening_time,
-        closing_time: body.closing_time,
-        business_days: body.business_days,
+        email: body.email ?? null,
+        capacity: body.capacity ?? null,
         is_active: true,
       })
       .select()


### PR DESCRIPTION
## Summary
- Update `/api/facilities` POST handler to insert only columns defined in `m_facilities` per docs/03_database.md (§4.2), removing unsupported fields
- Keep optional fields nullable and default `is_active` to true to match current schema while preserving required values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944de89453c8331ae7e607c4ed125b9)