### PR TITLE
メール送信をlibファイルに統合

### DIFF
--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -1,95 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 
+import { isBadRequestError, sendWithResend } from "@/lib/email/resend"
+import { BAD_REQUEST_MESSAGE, EmailRequestBody } from "@/lib/email/types"
 import { createClient } from "@/utils/supabase/server"
-
-type RecipientInput = string | string[] | undefined
-
-type EmailPayload = {
-  to: RecipientInput
-  cc?: RecipientInput
-  bcc?: RecipientInput
-  senderName?: string
-  subject?: string
-  htmlBody: string
-  replyTo?: string
-}
-
-type ResendResponseBody = {
-  id?: string
-  error?: { message?: string }
-  message?: string
-}
-
-const RESEND_API_KEY = process.env.RESEND_API_KEY
-const RESEND_FROM_EMAIL = process.env.RESEND_FROM_EMAIL
-const RESEND_ENDPOINT = "https://api.resend.com/emails"
-const DEFAULT_SUBJECT = "(no subject)"
-const DEFAULT_HTML_BODY =
-  "<p>このメールはResendの接続確認用に送信されています。</p><p>受信できたらメール配信機能の準備は完了です。</p>"
-const BAD_REQUEST_MESSAGE = "to と htmlBody は必須です"
-
-const normalizeRecipients = (value: RecipientInput): string[] => {
-  if (!value) return []
-
-  const list = Array.isArray(value) ? value : value.split(/,|\n/)
-
-  return list
-    .map((recipient) => recipient.trim())
-    .filter((recipient) => recipient.length > 0)
-}
-
-const buildHtmlBody = (body: EmailPayload & { email?: string; text?: string }): string => {
-  const html = typeof body?.htmlBody === "string" ? body.htmlBody.trim() : ""
-  if (html) return html
-
-  const text = typeof body?.text === "string" ? body.text.trim() : ""
-  if (text) return `<p>${text}</p>`
-
-  return DEFAULT_HTML_BODY
-}
-
-const sendWithResend = async (payload: EmailPayload) => {
-  if (!RESEND_API_KEY || !RESEND_FROM_EMAIL) {
-    throw new Error("メール送信設定が未完了です。RESEND_API_KEYとRESEND_FROM_EMAILを確認してください。")
-  }
-
-  const to = normalizeRecipients(payload.to)
-  if (to.length === 0) {
-    throw new Error(BAD_REQUEST_MESSAGE)
-  }
-
-  const cc = normalizeRecipients(payload.cc)
-  const bcc = normalizeRecipients(payload.bcc)
-  const subject = payload.subject?.trim() || DEFAULT_SUBJECT
-
-  const resendBody = {
-    from: payload.senderName ? `${payload.senderName} <${RESEND_FROM_EMAIL}>` : RESEND_FROM_EMAIL,
-    to,
-    cc: cc.length ? cc : undefined,
-    bcc: bcc.length ? bcc : undefined,
-    subject,
-    html: payload.htmlBody,
-    reply_to: payload.replyTo,
-  }
-
-  const response = await fetch(RESEND_ENDPOINT, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${RESEND_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(resendBody),
-  })
-
-  const body = (await response.json().catch(() => null)) as ResendResponseBody | null
-
-  if (!response.ok) {
-    const errorMessage = body?.error?.message || body?.message || "メール送信に失敗しました。設定を確認してください。"
-    throw new Error(errorMessage)
-  }
-
-  return body
-}
 
 export async function POST(request: NextRequest) {
   try {
@@ -103,40 +16,21 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, ok: false, error: "認証が必要です。" }, { status: 401 })
     }
 
-    const body = ((await request.json().catch(() => null)) || {}) as EmailPayload & {
-      email?: string
-      text?: string
-    }
+    const body = ((await request.json().catch(() => null)) || {}) as EmailRequestBody
 
-    const htmlBody = buildHtmlBody(body)
-    const payload: EmailPayload = {
-      to: body.to ?? body.email,
-      cc: body.cc,
-      bcc: body.bcc,
-      senderName: body.senderName,
-      subject: body.subject,
-      htmlBody,
-      replyTo: body.replyTo,
-    }
-
-    const toList = normalizeRecipients(payload.to)
-    if (toList.length === 0 || !payload.htmlBody?.trim()) {
-      return NextResponse.json({ success: false, ok: false, error: BAD_REQUEST_MESSAGE }, { status: 400 })
-    }
-
-    const responseBody = await sendWithResend(payload)
+    const result = await sendWithResend(body)
 
     return NextResponse.json({
       success: true,
       ok: true,
-      data: { id: responseBody?.id ?? null },
-      message: "sent",
+      data: { id: result.id ?? null },
+      message: result.message ?? "sent",
     })
   } catch (error) {
     console.error("メール送信エラー", error)
     const message = error instanceof Error ? error.message : "内部エラーが発生しました。"
 
-    const status = message === BAD_REQUEST_MESSAGE ? 400 : 500
+    const status = isBadRequestError(error) || message === BAD_REQUEST_MESSAGE ? 400 : 500
 
     return NextResponse.json({ success: false, ok: false, error: message }, { status })
   }

--- a/app/api/email_test/route.ts
+++ b/app/api/email_test/route.ts
@@ -1,108 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server'
-type RecipientInput = string | string[] | undefined
+import { NextRequest, NextResponse } from "next/server"
 
-type GasEmailRequest = {
-  to: RecipientInput
-  cc?: RecipientInput
-  bcc?: RecipientInput
-  senderName?: string
-  subject?: string
-  htmlBody: string
-  replyTo?: string
-}
-
-type GasEmailResponse = {
-  ok: boolean
-  message?: string
-  error?: string
-}
-
-const DEFAULT_SUBJECT = '(no subject)'
-const BAD_REQUEST_MESSAGE = 'to と htmlBody は必須です'
-
-const normalizeRecipients = (value: RecipientInput): string[] => {
-  if (!value) return []
-
-  const list = Array.isArray(value) ? value : value.split(/,|\n/)
-
-  return list
-    .map((recipient) => recipient.trim())
-    .filter((recipient) => recipient.length > 0)
-}
-
-const sendGasTestEmail = async (payload: GasEmailRequest): Promise<GasEmailResponse> => {
-  const endpoint = process.env.GAS_EMAIL_API_URL
-  if (!endpoint) {
-    throw new Error('メール送信エンドポイントが設定されていません')
-  }
-
-  const to = normalizeRecipients(payload.to)
-  if (to.length === 0) {
-    throw new Error('宛先は必須です')
-  }
-
-  const cc = normalizeRecipients(payload.cc)
-  const bcc = normalizeRecipients(payload.bcc)
-  const subject = payload.subject?.trim() || DEFAULT_SUBJECT
-
-  const body = {
-    to,
-    cc: cc.length ? cc : undefined,
-    bcc: bcc.length ? bcc : undefined,
-    senderName: payload.senderName,
-    subject,
-    htmlBody: payload.htmlBody,
-    replyTo: payload.replyTo,
-  }
-
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-
-  let result: GasEmailResponse | null = null
-  try {
-    result = (await response.json()) as GasEmailResponse
-  } catch (error) {
-    // JSON以外のレスポンスは null のまま扱う
-  }
-
-  if (!response.ok || !result?.ok) {
-    const errorMessage = result?.error || `メール送信に失敗しました (status: ${response.status})`
-    throw new Error(errorMessage)
-  }
-
-  return result
-}
+import { sendWithGas } from "@/lib/email/gas"
+import { BAD_REQUEST_MESSAGE, EmailRequestBody } from "@/lib/email/types"
 
 export async function POST(request: NextRequest) {
   try {
-    const body = (await request.json()) as GasEmailRequest
-
-    if (!body?.to || !body?.htmlBody) {
-      return NextResponse.json({ ok: false, error: BAD_REQUEST_MESSAGE }, { status: 400 })
-    }
-
-    const payload: GasEmailRequest = {
-      to: body.to,
-      cc: body.cc,
-      bcc: body.bcc,
-      senderName: body.senderName,
-      subject: body.subject,
-      htmlBody: body.htmlBody,
-      replyTo: body.replyTo,
-    }
-
-    const result = await sendGasTestEmail(payload)
+    const body = ((await request.json().catch(() => null)) || {}) as EmailRequestBody
+    const result = await sendWithGas(body)
 
     return NextResponse.json({
       ok: result.ok,
-      message: result.message ?? 'sent',
+      message: result.message ?? "sent",
     })
   } catch (error) {
-    console.error('メール送信テストエラー', error)
-    const message = error instanceof Error ? error.message : 'メール送信に失敗しました'
-    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+    console.error("メール送信テストエラー", error)
+    const message = error instanceof Error ? error.message : "メール送信に失敗しました"
+    const status = message === BAD_REQUEST_MESSAGE ? 400 : 500
+
+    return NextResponse.json({ ok: false, error: message }, { status })
   }
 }

--- a/lib/email/gas.ts
+++ b/lib/email/gas.ts
@@ -1,0 +1,52 @@
+import { BAD_REQUEST_MESSAGE, EmailRequestBody, EmailSendResult } from "./types"
+import { buildEmailPayload } from "./utils"
+
+const sendGasTestEmail = async (payload: EmailRequestBody) => {
+  const endpoint = process.env.GAS_EMAIL_API_URL
+  if (!endpoint) {
+    throw new Error("メール送信エンドポイントが設定されていません")
+  }
+
+  const normalized = buildEmailPayload(payload)
+
+  const body = {
+    to: normalized.to,
+    cc: normalized.cc?.length ? normalized.cc : undefined,
+    bcc: normalized.bcc?.length ? normalized.bcc : undefined,
+    senderName: normalized.senderName,
+    subject: normalized.subject,
+    htmlBody: normalized.htmlBody,
+    replyTo: normalized.replyTo,
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+
+  let result: { ok: boolean; message?: string; error?: string } | null = null
+  try {
+    result = (await response.json()) as { ok: boolean; message?: string; error?: string }
+  } catch (error) {
+    // 非JSONの場合は null のまま扱う
+  }
+
+  if (!response.ok || !result?.ok) {
+    const errorMessage = result?.error || `メール送信に失敗しました (status: ${response.status})`
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+export const sendWithGas = async (rawBody: EmailRequestBody): Promise<EmailSendResult> => {
+  const result = await sendGasTestEmail(rawBody)
+
+  return {
+    ok: result.ok,
+    message: result.message ?? "sent",
+  }
+}
+
+export const isBadRequestError = (error: unknown) => error instanceof Error && error.message === BAD_REQUEST_MESSAGE

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -1,0 +1,54 @@
+import { BAD_REQUEST_MESSAGE, EmailRequestBody, EmailSendResult } from "./types"
+import { buildEmailPayload } from "./utils"
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY
+const RESEND_FROM_EMAIL = process.env.RESEND_FROM_EMAIL
+const RESEND_ENDPOINT = "https://api.resend.com/emails"
+
+type ResendResponseBody = {
+  id?: string
+  error?: { message?: string }
+  message?: string
+}
+
+export const sendWithResend = async (rawBody: EmailRequestBody): Promise<EmailSendResult> => {
+  if (!RESEND_API_KEY || !RESEND_FROM_EMAIL) {
+    throw new Error("メール送信設定が未完了です。RESEND_API_KEYとRESEND_FROM_EMAILを確認してください。")
+  }
+
+  const payload = buildEmailPayload(rawBody)
+
+  const resendBody = {
+    from: payload.senderName ? `${payload.senderName} <${RESEND_FROM_EMAIL}>` : RESEND_FROM_EMAIL,
+    to: payload.to,
+    cc: payload.cc?.length ? payload.cc : undefined,
+    bcc: payload.bcc?.length ? payload.bcc : undefined,
+    subject: payload.subject,
+    html: payload.htmlBody,
+    reply_to: payload.replyTo,
+  }
+
+  const response = await fetch(RESEND_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(resendBody),
+  })
+
+  const body = (await response.json().catch(() => null)) as ResendResponseBody | null
+
+  if (!response.ok) {
+    const errorMessage = body?.error?.message || body?.message || "メール送信に失敗しました。設定を確認してください。"
+    throw new Error(errorMessage)
+  }
+
+  return {
+    ok: true,
+    id: body?.id ?? null,
+    message: "sent",
+  }
+}
+
+export const isBadRequestError = (error: unknown) => error instanceof Error && error.message === BAD_REQUEST_MESSAGE

--- a/lib/email/types.ts
+++ b/lib/email/types.ts
@@ -1,0 +1,35 @@
+export type RecipientInput = string | string[] | undefined
+
+export type EmailRequestBody = {
+  to: RecipientInput
+  cc?: RecipientInput
+  bcc?: RecipientInput
+  senderName?: string
+  subject?: string
+  htmlBody?: string
+  replyTo?: string
+  // Legacy fields for backward compatibility
+  email?: string
+  text?: string
+}
+
+export type EmailPayload = {
+  to: string[]
+  cc?: string[]
+  bcc?: string[]
+  senderName?: string
+  subject: string
+  htmlBody: string
+  replyTo?: string
+}
+
+export type EmailSendResult = {
+  ok: boolean
+  message?: string
+  id?: string | null
+}
+
+export const BAD_REQUEST_MESSAGE = "to と htmlBody は必須です"
+export const DEFAULT_SUBJECT = "(no subject)"
+export const DEFAULT_HTML_BODY =
+  "<p>このメールはResendの接続確認用に送信されています。</p><p>受信できたらメール配信機能の準備は完了です。</p>"

--- a/lib/email/utils.ts
+++ b/lib/email/utils.ts
@@ -1,0 +1,39 @@
+import { BAD_REQUEST_MESSAGE, DEFAULT_HTML_BODY, DEFAULT_SUBJECT, EmailPayload, EmailRequestBody, RecipientInput } from "./types"
+
+export const normalizeRecipients = (value: RecipientInput): string[] => {
+  if (!value) return []
+
+  const list = Array.isArray(value) ? value : value.split(/,|\n/)
+
+  return list
+    .map((recipient) => recipient.trim())
+    .filter((recipient) => recipient.length > 0)
+}
+
+const buildHtmlBody = (body: EmailRequestBody): string => {
+  const html = typeof body?.htmlBody === "string" ? body.htmlBody.trim() : ""
+  if (html) return html
+
+  const text = typeof body?.text === "string" ? body.text.trim() : ""
+  if (text) return `<p>${text}</p>`
+
+  return DEFAULT_HTML_BODY
+}
+
+export const buildEmailPayload = (raw: EmailRequestBody): EmailPayload => {
+  const payload: EmailPayload = {
+    to: normalizeRecipients(raw.to ?? raw.email),
+    cc: normalizeRecipients(raw.cc),
+    bcc: normalizeRecipients(raw.bcc),
+    senderName: raw.senderName,
+    subject: raw.subject?.trim() || DEFAULT_SUBJECT,
+    htmlBody: buildHtmlBody(raw),
+    replyTo: raw.replyTo,
+  }
+
+  if (payload.to.length === 0 || !payload.htmlBody.trim()) {
+    throw new Error(BAD_REQUEST_MESSAGE)
+  }
+
+  return payload
+}


### PR DESCRIPTION
## Summary
- Update /api/email to accept the same payload shape as the GAS test endpoint while calling Resend
- Normalize recipient fields, defaults, and optional text/html handling so extra fields are safely ignored
- Preserve auth gate and return consistent success/error structure to avoid client-side breaks

## Testing
- Not run (not requested)

## Spec Alignment
- Keeps mail delivery scoped to test/operational verification only, consistent with the out-of-scope note for production mail delivery (docs/01_requirements.md)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69450ae07bb08331b39912684b25839c)