### PR TITLE
feat: 活動記録一覧から個別記録を開く導線を追加

### DIFF
--- a/__tests__/api/activities-observations.get.test.ts
+++ b/__tests__/api/activities-observations.get.test.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/activities/[id]/observations/route';
+import { createClient } from '@/utils/supabase/server';
+import { getUserSession } from '@/lib/auth/session';
+
+jest.mock('@/utils/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/session', () => ({
+  getUserSession: jest.fn(),
+}));
+
+const buildRequest = () =>
+  new NextRequest('http://localhost/api/activities/activity-1/observations', {
+    method: 'GET',
+  });
+
+describe('GET /api/activities/:id/observations', () => {
+  const mockedCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+  const mockedGetUserSession = getUserSession as jest.MockedFunction<typeof getUserSession>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns observations linked to the activity', async () => {
+    mockedGetUserSession.mockResolvedValue({
+      user_id: 'user-1',
+      email: 'test@example.com',
+      name: 'テスト',
+      role: 'staff',
+      company_id: 'company-1',
+      company_name: 'Test Co',
+      current_facility_id: 'facility-1',
+      facilities: [],
+      classes: [],
+    });
+
+    const authQuery = {
+      getSession: jest.fn().mockResolvedValue({
+        data: { session: { user: { id: 'user-1' } } },
+        error: null,
+      }),
+    };
+
+    const activityQuery: any = {
+      select: jest.fn(() => activityQuery),
+      eq: jest.fn(() => activityQuery),
+      is: jest.fn(() => activityQuery),
+      single: jest.fn().mockResolvedValue({
+        data: { id: 'activity-1', facility_id: 'facility-1' },
+        error: null,
+      }),
+    };
+
+    const observationQuery: any = {
+      select: jest.fn(() => observationQuery),
+      eq: jest.fn(() => observationQuery),
+      is: jest.fn(() => observationQuery),
+      order: jest.fn().mockResolvedValue({
+        data: [
+          {
+            id: 'obs-1',
+            child_id: 'child-1',
+            observation_date: '2024-01-01',
+            content: 'ブロックで遊んだ',
+            created_at: '2024-01-01T00:00:00.000Z',
+            m_children: {
+              family_name: '山田',
+              given_name: '花子',
+              nickname: 'はな',
+            },
+          },
+        ],
+        error: null,
+      }),
+    };
+
+    const mockSupabase = {
+      auth: authQuery,
+      from: jest.fn((table: string) => {
+        if (table === 'r_activity') return activityQuery;
+        if (table === 'r_observation') return observationQuery;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    mockedCreateClient.mockResolvedValue(mockSupabase as any);
+
+    const response = await GET(buildRequest(), { params: Promise.resolve({ id: 'activity-1' }) });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.observations).toHaveLength(1);
+    expect(json.data.observations[0]).toMatchObject({
+      observation_id: 'obs-1',
+      child_id: 'child-1',
+      child_name: 'はな',
+    });
+    expect(activityQuery.eq).toHaveBeenCalledWith('id', 'activity-1');
+  });
+});

--- a/app/api/activities/[id]/observations/route.ts
+++ b/app/api/activities/[id]/observations/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+import { getUserSession } from '@/lib/auth/session';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { session },
+      error: authError,
+    } = await supabase.auth.getSession();
+
+    if (authError || !session) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userSession = await getUserSession(session.user.id);
+    if (!userSession?.current_facility_id) {
+      return NextResponse.json(
+        { success: false, error: 'Facility not found in session' },
+        { status: 400 },
+      );
+    }
+
+    const { id } = await params;
+
+    const { data: activity, error: activityError } = await supabase
+      .from('r_activity')
+      .select('id, facility_id')
+      .eq('id', id)
+      .is('deleted_at', null)
+      .single();
+
+    if (activityError || !activity) {
+      return NextResponse.json(
+        { success: false, error: '活動記録が見つかりませんでした' },
+        { status: 404 },
+      );
+    }
+
+    if (activity.facility_id !== userSession.current_facility_id) {
+      return NextResponse.json(
+        { success: false, error: 'この活動記録にアクセスする権限がありません' },
+        { status: 403 },
+      );
+    }
+
+    const { data: observations, error: observationsError } = await supabase
+      .from('r_observation')
+      .select(
+        `
+        id,
+        child_id,
+        observation_date,
+        content,
+        created_at,
+        m_children!inner (
+          family_name,
+          given_name,
+          nickname
+        )
+      `,
+      )
+      .eq('activity_id', id)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: true });
+
+    if (observationsError) {
+      console.error('Observations fetch error:', observationsError);
+      return NextResponse.json(
+        { success: false, error: '個別記録の取得に失敗しました' },
+        { status: 500 },
+      );
+    }
+
+    const formatted = (observations || []).map((observation: any) => {
+      const child = Array.isArray(observation.m_children)
+        ? observation.m_children[0]
+        : observation.m_children;
+      const childName =
+        child?.nickname || [child?.family_name, child?.given_name].filter(Boolean).join(' ') || '';
+
+      return {
+        observation_id: observation.id,
+        child_id: observation.child_id,
+        child_name: childName,
+        observation_date: observation.observation_date,
+        content: observation.content,
+        created_at: observation.created_at,
+      };
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        observations: formatted,
+      },
+    });
+  } catch (error) {
+    console.error('Activity observations API error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- 活動記録一覧から、その活動に紐づく個別記録（観察記録）を直接参照・編集できる導線を追加するため。 
- 編集フローへ遷移することで、AIで生成したドラフトや手動で作成した個別記録の確認を容易にするため。 
- サーバー側で活動に紐づく個別記録を安全に取得するAPIを提供するため。 

### Description
- `app/records/activity/activity-record-client.tsx` に `ActivityObservation` 型と状態管理、`handleOpenObservations` ハンドラ、`個別記録を開く` ボタン、および個別記録一覧モーダルを追加してクライアント側の導線を実装しました。 
- `app/api/activities/[id]/observations/route.ts` を追加し、セッション／所属施設の検証後に `r_observation` と結合した子ども名を整形して返す `GET` エンドポイントを実装しました。 
- `__tests__/api/activities-observations.get.test.ts` を追加して、Supabase クライアントと `getUserSession` をモックした上で API レスポンスを検証する単体テストを実装しました。 

### Testing
- 実装した API の単体テストを `npm test -- __tests__/api/activities-observations.get.test.ts` で実行し、テストは `PASS` しました。 
- 追加したテストは Supabase のクエリ呼び出しをモックしており、期待する JSON 形式と `activity` フィルタの呼び出しを検証しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608676dfa48331914ff88f7f180619)