### PR TITLE
feat: 活動記録カードに個別記録リンクを追加

### DIFF
--- a/app/records/activity/activity-record-client.tsx
+++ b/app/records/activity/activity-record-client.tsx
@@ -43,6 +43,7 @@ interface Activity {
   created_at: string
   individual_record_count: number
   mentioned_children?: string[]
+  derived_observations?: DerivedObservation[]
 }
 
 interface ActivityPhoto {
@@ -51,6 +52,12 @@ interface ActivityPhoto {
   thumbnail_url?: string | null
   file_id?: string
   file_path?: string
+}
+
+interface DerivedObservation {
+  observation_id: string
+  child_id: string
+  child_name: string
 }
 
 interface MentionSuggestion {
@@ -549,6 +556,7 @@ export default function ActivityRecordClient() {
           ai_action: aiResult.data?.objective ?? '',
           ai_opinion: aiResult.data?.subjective ?? '',
           tag_flags: aiResult.data?.flags ?? {},
+          ...(editingActivityId ? { activity_id: editingActivityId } : {}),
         }),
       })
 
@@ -1087,13 +1095,29 @@ export default function ActivityRecordClient() {
                         </div>
                       </div>
 
-                      <div className="flex items-center justify-between pt-2 border-t">
-                        <span className="text-xs text-muted-foreground">
-                          {activity.individual_record_count}件の個別記録
-                        </span>
-                        <span className="text-xs text-muted-foreground">
-                          作成: {activity.created_by}
-                        </span>
+                      <div className="pt-2 border-t space-y-2">
+                        {activity.derived_observations?.length ? (
+                          <div className="flex flex-wrap gap-2">
+                            {activity.derived_observations.map((observation) => (
+                              <Button
+                                key={observation.observation_id}
+                                size="sm"
+                                variant="outline"
+                                aria-label={observation.child_name || "名称未設定"}
+                                onClick={() =>
+                                  router.push(`/records/personal/${observation.observation_id}/edit`)
+                                }
+                              >
+                                {observation.child_name}
+                              </Button>
+                            ))}
+                          </div>
+                        ) : null}
+                        <div className="flex items-center justify-end">
+                          <span className="text-xs text-muted-foreground">
+                            作成: {activity.created_by}
+                          </span>
+                        </div>
                       </div>
                     </div>
                   </CardContent>


### PR DESCRIPTION
### Motivation
- 活動記録から派生した個別観察記録へ直接遷移できるようにして運用を効率化するため。
- 個別記録を件数だけでなく子どものフルネームで示して識別しやすくするため。
- 個別記録作成時に元の活動記録 (`activity_id`) を紐付けてトレーサビリティを保つため。
- 施設スコープ外の関連データ保存を防ぐために権限チェックを追加するため。

### Description
- 拡張 `/api/activities` の GET で `r_observation` をまとめて取得し、`derived_observations`（`observation_id`/`child_id`/`child_name`）をレスポンスに追加したことにより画面側で子ども名ボタンを生成可能にしました. 
- `/api/records/personal` の POST でリクエストパラメータに `activity_id` を受け取り、`r_activity` の施設スコープを検証した上で `r_observation.activity_id` に保存するようにしました。 
- クライアント (`app/records/activity/activity-record-client.tsx`) に `DerivedObservation` 型を追加して、AI保存時に `activity_id` を送信するようにし、活動カードに子ども名の小さなボタンを並べて `/records/personal/{observation_id}/edit` へ遷移する UI を実装しました。 
- DB フェッチ時のエラー処理（観察記録取得エラーのログと 500 応答）や、空データ時のフォールバック処理を追加しました。

### Testing
- 起動: `npm run dev -- --hostname 0.0.0.0 --port 3000` を実行して Next.js 開発サーバは起動済み（Next.js ready）。
- UI 結合チェック: Playwright スクリプトで `/records/activity` のスクリーンショットを取得してアーティファクトを生成できました（`activity-records.png`）。
- API 実行: 実行環境で Supabase の環境変数が未設定のため API 呼び出しで Supabase クライアント初期化エラーが発生し一部動作確認は失敗しました。 
- 自動ユニットテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696095c028d4833187f0080ad56ba833)