### PR TITLE
fix: 施設設定読み取り専用化・クラス追加ボタン追加・施設一覧N+1クエリ修正

### DIFF
--- a/app/api/facilities/route.ts
+++ b/app/api/facilities/route.ts
@@ -56,45 +56,59 @@ export async function GET(request: NextRequest) {
       throw facilitiesError;
     }
 
-    // 各施設の統計情報を取得
-    const facilitiesWithStats = await Promise.all(
-      (facilities || []).map(async (facility) => {
-        // クラス数
-        const { count: classCount } = await supabase
+    // 施設IDリストを取得して統計情報を一括取得（N+1クエリ解消）
+    const facilityIds = (facilities || []).map((f) => f.id);
+
+    const [classRowsResult, childrenRowsResult, staffRowsResult] =
+      await Promise.all([
+        // クラス数: 一括取得
+        supabase
           .from('m_classes')
-          .select('*', { count: 'exact', head: true })
-          .eq('facility_id', facility.id)
-          .is('deleted_at', null);
-
-        // 児童数
-        const { count: childrenCount } = await supabase
+          .select('facility_id')
+          .in('facility_id', facilityIds)
+          .is('deleted_at', null),
+        // 児童数: 一括取得（在籍中のみ）
+        supabase
           .from('m_children')
-          .select('*', { count: 'exact', head: true })
-          .eq('facility_id', facility.id)
+          .select('facility_id')
+          .in('facility_id', facilityIds)
           .eq('enrollment_status', 'enrolled')
-          .is('deleted_at', null);
-
-        // 職員数
-        const { count: staffCount } = await supabase
+          .is('deleted_at', null),
+        // 職員数: 一括取得（現職のみ）
+        supabase
           .from('_user_facility')
-          .select('*', { count: 'exact', head: true })
-          .eq('facility_id', facility.id)
-          .eq('is_current', true);
+          .select('facility_id')
+          .in('facility_id', facilityIds)
+          .eq('is_current', true),
+      ]);
 
-        return {
-          facility_id: facility.id,
-          name: facility.name,
-          address: facility.address,
-          phone: facility.phone,
-          email: facility.email,
-          class_count: classCount || 0,
-          children_count: childrenCount || 0,
-          staff_count: staffCount || 0,
-          created_at: facility.created_at,
-          updated_at: facility.updated_at,
-        };
-      })
-    );
+    const countByFacilityId = (
+      rows: { facility_id: string }[] | null
+    ): Record<string, number> =>
+      (rows || []).reduce(
+        (acc, row) => {
+          acc[row.facility_id] = (acc[row.facility_id] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>
+      );
+
+    const classCountMap = countByFacilityId(classRowsResult.data);
+    const childrenCountMap = countByFacilityId(childrenRowsResult.data);
+    const staffCountMap = countByFacilityId(staffRowsResult.data);
+
+    const facilitiesWithStats = (facilities || []).map((facility) => ({
+      facility_id: facility.id,
+      name: facility.name,
+      address: facility.address,
+      phone: facility.phone,
+      email: facility.email,
+      class_count: classCountMap[facility.id] || 0,
+      children_count: childrenCountMap[facility.id] || 0,
+      staff_count: staffCountMap[facility.id] || 0,
+      created_at: facility.created_at,
+      updated_at: facility.updated_at,
+    }));
 
     // 検索フィルタ（ひらがな/カタカナ表記ゆれ・全角半角スペース対応）
     let filteredFacilities = facilitiesWithStats;

--- a/app/settings/classes/page.tsx
+++ b/app/settings/classes/page.tsx
@@ -2,14 +2,18 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRole } from '@/hooks/useRole';
+import { useSession } from '@/hooks/useSession';
 import { StaffLayout } from "@/components/layout/staff-layout";
+import * as Dialog from '@radix-ui/react-dialog';
 import {
   Users,
   Search,
   Building2,
   ChevronRight,
   UserCheck,
-  Filter
+  Filter,
+  Plus,
+  X,
 } from 'lucide-react';
 
 interface Class {
@@ -35,8 +39,25 @@ interface Facility {
   name: string;
 }
 
+interface AddClassForm {
+  name: string;
+  capacity: string;
+  age_group: string;
+  room_number: string;
+  facility_id: string;
+}
+
+const INITIAL_FORM: AddClassForm = {
+  name: '',
+  capacity: '',
+  age_group: '',
+  room_number: '',
+  facility_id: '',
+};
+
 export default function ClassesListPage() {
-  const { isStaff } = useRole();
+  const { isStaff, hasRole } = useRole();
+  const session = useSession();
   const router = useRouter();
   const [classes, setClasses] = useState<Class[]>([]);
   const [facilities, setFacilities] = useState<Facility[]>([]);
@@ -44,6 +65,14 @@ export default function ClassesListPage() {
   const [filterFacility, setFilterFacility] = useState('all');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // モーダル状態
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [form, setForm] = useState<AddClassForm>(INITIAL_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const canAddClass = hasRole('facility_admin', 'company_admin', 'site_admin');
 
   useEffect(() => {
     if (isStaff) router.replace('/dashboard');
@@ -108,6 +137,64 @@ export default function ClassesListPage() {
     fetchClasses();
   };
 
+  // モーダルを開く（facility_id の初期値を設定）
+  const openDialog = () => {
+    const defaultFacilityId =
+      filterFacility !== 'all'
+        ? filterFacility
+        : (session?.current_facility_id ?? facilities[0]?.facility_id ?? '');
+    setForm({ ...INITIAL_FORM, facility_id: defaultFacilityId });
+    setFormError(null);
+    setDialogOpen(true);
+  };
+
+  // クラス追加送信
+  const handleAddClass = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+
+    if (!form.name.trim()) {
+      setFormError('クラス名を入力してください');
+      return;
+    }
+    const capacityNum = parseInt(form.capacity, 10);
+    if (!form.capacity || isNaN(capacityNum) || capacityNum < 1) {
+      setFormError('定員は1以上の数値を入力してください');
+      return;
+    }
+    if (!form.facility_id) {
+      setFormError('施設を選択してください');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/classes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          facility_id: form.facility_id,
+          name: form.name.trim(),
+          capacity: capacityNum,
+          age_group: form.age_group.trim() || undefined,
+          room_number: form.room_number.trim() || undefined,
+        }),
+      });
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'クラスの作成に失敗しました');
+      }
+
+      setDialogOpen(false);
+      fetchClasses();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'クラスの作成に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   // 施設フィルタ変更時
   useEffect(() => {
     if (facilities.length > 0) {
@@ -133,6 +220,138 @@ export default function ClassesListPage() {
                 {loading ? '読み込み中...' : `全 ${classes.length} クラスを管理`}
               </p>
             </div>
+            {canAddClass && (
+              <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
+                <Dialog.Trigger asChild>
+                  <button
+                    onClick={openDialog}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg font-medium text-sm transition-colors shrink-0"
+                  >
+                    <Plus size={16} />
+                    クラスを追加
+                  </button>
+                </Dialog.Trigger>
+
+                <Dialog.Portal>
+                  <Dialog.Overlay className="fixed inset-0 bg-black/40 z-40" />
+                  <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 bg-white rounded-xl shadow-xl p-6 focus:outline-none">
+                    <div className="flex items-center justify-between mb-5">
+                      <Dialog.Title className="text-lg font-bold text-slate-800">
+                        クラスを追加
+                      </Dialog.Title>
+                      <Dialog.Close className="text-slate-400 hover:text-slate-600 transition-colors">
+                        <X size={20} />
+                      </Dialog.Close>
+                    </div>
+
+                    <form onSubmit={handleAddClass} className="space-y-4">
+                      {/* 施設選択 */}
+                      <div>
+                        <label className="block text-sm font-medium text-slate-700 mb-1">
+                          施設 <span className="text-red-500">*</span>
+                        </label>
+                        <select
+                          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-slate-700 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          value={form.facility_id}
+                          onChange={(e) => setForm({ ...form, facility_id: e.target.value })}
+                          required
+                        >
+                          <option value="">施設を選択してください</option>
+                          {facilities.map((f) => (
+                            <option key={f.facility_id} value={f.facility_id}>
+                              {f.name}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      {/* クラス名 */}
+                      <div>
+                        <label className="block text-sm font-medium text-slate-700 mb-1">
+                          クラス名 <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                          type="text"
+                          placeholder="例: ひまわり組"
+                          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          value={form.name}
+                          onChange={(e) => setForm({ ...form, name: e.target.value })}
+                          required
+                        />
+                      </div>
+
+                      {/* 定員 */}
+                      <div>
+                        <label className="block text-sm font-medium text-slate-700 mb-1">
+                          定員 <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                          type="number"
+                          min={1}
+                          placeholder="例: 20"
+                          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          value={form.capacity}
+                          onChange={(e) => setForm({ ...form, capacity: e.target.value })}
+                          required
+                        />
+                      </div>
+
+                      {/* 年齢グループ */}
+                      <div>
+                        <label className="block text-sm font-medium text-slate-700 mb-1">
+                          年齢グループ
+                        </label>
+                        <input
+                          type="text"
+                          placeholder="例: 小1〜小3"
+                          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          value={form.age_group}
+                          onChange={(e) => setForm({ ...form, age_group: e.target.value })}
+                        />
+                      </div>
+
+                      {/* 部屋番号 */}
+                      <div>
+                        <label className="block text-sm font-medium text-slate-700 mb-1">
+                          部屋番号
+                        </label>
+                        <input
+                          type="text"
+                          placeholder="例: 101"
+                          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          value={form.room_number}
+                          onChange={(e) => setForm({ ...form, room_number: e.target.value })}
+                        />
+                      </div>
+
+                      {formError && (
+                        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+                          {formError}
+                        </p>
+                      )}
+
+                      <div className="flex justify-end gap-3 pt-2">
+                        <Dialog.Close asChild>
+                          <button
+                            type="button"
+                            className="px-4 py-2 text-sm font-medium text-slate-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                          >
+                            キャンセル
+                          </button>
+                        </Dialog.Close>
+                        <button
+                          type="submit"
+                          disabled={submitting}
+                          className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {submitting ? '作成中...' : '追加する'}
+                        </button>
+                      </div>
+                    </form>
+                  </Dialog.Content>
+                </Dialog.Portal>
+              </Dialog.Root>
+            )}
           </div>
 
           {/* Filter Toolbar */}

--- a/app/settings/facility/[facility_id]/page.tsx
+++ b/app/settings/facility/[facility_id]/page.tsx
@@ -8,14 +8,9 @@ import {
   Building2,
   MapPin,
   Phone,
-  Save,
   Plus,
-  X,
-  Trash2,
   Users,
   ChevronLeft,
-  UserCheck,
-  ChevronRight,
   CheckCircle2,
   ArrowRight
 } from 'lucide-react';
@@ -226,7 +221,6 @@ export default function FacilityDetailPage() {
 
   const [facility, setFacility] = useState<Facility | null>(null);
   const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [showAddDialog, setShowAddDialog] = useState(false);
@@ -304,53 +298,6 @@ export default function FacilityDetailPage() {
     }
   };
 
-  const handleSave = async () => {
-    if (!facility) return;
-
-    try {
-      setSaving(true);
-      setError(null);
-
-      const isNew = facilityId === 'new';
-      const url = isNew ? '/api/facilities' : `/api/facilities/${facilityId}`;
-      const method = isNew ? 'POST' : 'PUT';
-
-      const response = await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: facility.name,
-          name_kana: facility.name_kana || null,
-          address: facility.address,
-          phone: facility.phone,
-          postal_code: facility.postal_code || null,
-          capacity: facility.capacity != null ? facility.capacity : null,
-        }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok || !data.success) {
-        throw new Error(data.error || 'Failed to save facility');
-      }
-
-      alert(data.message || '施設情報を保存しました');
-
-      if (isNew) {
-        // 新規作成の場合は一覧ページに戻る
-        router.push('/settings/facility');
-      } else {
-        // 更新の場合はデータを再取得
-        fetchFacility();
-      }
-    } catch (err) {
-      console.error('Error saving facility:', err);
-      setError(err instanceof Error ? err.message : 'Failed to save facility');
-    } finally {
-      setSaving(false);
-    }
-  };
-
   // Load facility data
   useEffect(() => {
     if (facilityId && facilityId !== 'new') {
@@ -399,7 +346,7 @@ export default function FacilityDetailPage() {
 
   return (
     <StaffLayout title="施設詳細">
-      <div className="min-h-screen bg-gray-50 text-slate-900 font-sans pb-24">
+      <div className="min-h-screen bg-gray-50 text-slate-900 font-sans">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
           {/* Back Button */}
@@ -416,10 +363,10 @@ export default function FacilityDetailPage() {
             <div>
               <h1 className="text-2xl font-bold text-slate-800 flex items-center gap-2">
                 <Building2 className="text-indigo-500" />
-                施設情報編集
+                施設情報
               </h1>
               <p className="text-sm text-slate-500 mt-1">
-                施設の基本情報を編集
+                施設の基本情報
               </p>
             </div>
           </div>
@@ -442,16 +389,14 @@ export default function FacilityDetailPage() {
                   <Input
                     icon={Building2}
                     value={facility.name}
-                    onChange={(e: any) => setFacility({ ...facility, name: e.target.value })}
-                    placeholder="例: ひまわり保育園 本園"
+                    readOnly
                   />
                 </FieldGroup>
 
                 <FieldGroup label="施設名カナ">
                   <Input
                     value={facility.name_kana || ''}
-                    onChange={(e: any) => setFacility({ ...facility, name_kana: e.target.value })}
-                    placeholder="例: ヒマワリホイクエン ホンエン"
+                    readOnly
                   />
                 </FieldGroup>
               </div>
@@ -460,8 +405,7 @@ export default function FacilityDetailPage() {
                 <FieldGroup label="郵便番号">
                   <Input
                     value={facility.postal_code || ''}
-                    onChange={(e: any) => setFacility({ ...facility, postal_code: e.target.value })}
-                    placeholder="150-0001"
+                    readOnly
                   />
                 </FieldGroup>
 
@@ -469,8 +413,7 @@ export default function FacilityDetailPage() {
                   <Input
                     type="number"
                     value={facility.capacity != null ? String(facility.capacity) : ''}
-                    onChange={(e: any) => setFacility({ ...facility, capacity: e.target.value ? Number(e.target.value) : null })}
-                    placeholder="例: 40"
+                    readOnly
                   />
                 </FieldGroup>
               </div>
@@ -479,8 +422,7 @@ export default function FacilityDetailPage() {
                 <Input
                   icon={MapPin}
                   value={facility.address}
-                  onChange={(e: any) => setFacility({ ...facility, address: e.target.value })}
-                  placeholder="東京都渋谷区〇〇町1-2-3"
+                  readOnly
                 />
               </FieldGroup>
 
@@ -489,8 +431,7 @@ export default function FacilityDetailPage() {
                   icon={Phone}
                   type="tel"
                   value={facility.phone}
-                  onChange={(e: any) => setFacility({ ...facility, phone: e.target.value })}
-                  placeholder="03-1234-5678"
+                  readOnly
                 />
               </FieldGroup>
             </div>
@@ -635,37 +576,6 @@ export default function FacilityDetailPage() {
             </DialogContent>
           </Dialog>}
 
-        </div>
-
-        {/* Sticky Action Bar */}
-        <div className="fixed bottom-0 left-0 right-0 bg-white/80 backdrop-blur-md border-t border-slate-200 p-4 z-40">
-          <div className="max-w-5xl mx-auto flex items-center justify-between px-4 sm:px-6">
-            <button
-              type="button"
-              onClick={() => router.push('/settings/facility')}
-              className="text-slate-500 hover:text-slate-800 font-medium text-sm px-4 py-2 transition-colors"
-            >
-              キャンセル
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={saving || !facility.name || !facility.address || !facility.phone}
-              className="bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2.5 px-8 rounded-lg shadow-md shadow-indigo-200 hover:shadow-lg transition-all text-sm flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {saving ? (
-                <>
-                  <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full"></div>
-                  保存中...
-                </>
-              ) : (
-                <>
-                  <Save size={18} />
-                  変更を保存
-                </>
-              )}
-            </button>
-          </div>
         </div>
 
       </div>


### PR DESCRIPTION
## 対応チケット

- 施設情報が保存できない → 施設情報ページを読み取り専用に変更
- 施設情報取得・詳細ページの読み込み速度改善 → N+1クエリ修正
- クラス追加ボタンがない → クラス追加ボタン＋モーダル実装

## 変更内容

### 施設情報ページを読み取り専用化（`/settings/facility/[id]`）
- 保存ボタン・キャンセルボタンを削除
- 全フォームフィールドに `readOnly` を付与（文言変更も不可）
- ページタイトルを「施設情報編集」→「施設情報」に変更

### 施設一覧APIのN+1クエリ修正（`/api/facilities`）
- 施設ごとに個別クエリを発行していた統計取得（3N+1クエリ）を一括IN句取得に変更（4クエリ固定）

### クラス追加ボタン＋モーダル実装（`/settings/classes`）
- `facility_admin` 以上のロールに「クラスを追加」ボタンを表示
- Radix UI Dialog でクラス名・定員・施設・年齢グループを入力するフォームを実装
- `POST /api/classes` で登録後、一覧を自動更新

## Test plan
- [ ] 施設情報ページでフォームが編集不可になっていることを確認
- [ ] 施設一覧ページの読み込みが速くなっていることを確認
- [ ] facility_admin でクラス追加ボタンが表示されることを確認
- [ ] クラス追加モーダルからクラスを登録できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)