### PR TITLE
fix: 会社新規登録APIのRLS違反によるサーバーエラーを修正

### DIFF
--- a/__tests__/api/admin/companies.test.ts
+++ b/__tests__/api/admin/companies.test.ts
@@ -492,15 +492,9 @@ describe('POST /api/admin/companies', () => {
       }),
     };
 
-    let usersQueryCallCount = 0;
     const mockSupabase = {
       from: jest.fn((table: string) => {
-        if (table === 'm_companies') return companyInsertQuery;
-        if (table === 'm_users') {
-          usersQueryCallCount++;
-          if (usersQueryCallCount === 1) return usersEmailCheckQuery;
-          return usersUpdateQuery;
-        }
+        if (table === 'm_users') return usersEmailCheckQuery;
         throw new Error(`Unexpected table: ${table}`);
       }),
     };
@@ -508,6 +502,11 @@ describe('POST /api/admin/companies', () => {
     mockedCreateClient.mockResolvedValue(mockSupabase as any);
 
     const mockAdminClient = {
+      from: jest.fn((table: string) => {
+        if (table === 'm_companies') return companyInsertQuery;
+        if (table === 'm_users') return usersUpdateQuery;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
       auth: {
         admin: {
           getUserById: jest.fn().mockResolvedValue({
@@ -604,14 +603,17 @@ describe('POST /api/admin/companies', () => {
 
     const mockSupabase = {
       from: jest.fn((table: string) => {
-        if (table === 'm_users' && !companyInsertQuery.insert.mock.calls.length) return usersCheckQuery;
-        if (table === 'm_companies') return companyInsertQuery;
-        if (table === 'm_users') return userInsertQuery;
+        if (table === 'm_users') return usersCheckQuery;
         throw new Error(`Unexpected table: ${table}`);
       }),
     };
 
     const mockAdminClient = {
+      from: jest.fn((table: string) => {
+        if (table === 'm_companies') return companyInsertQuery;
+        if (table === 'm_users') return userInsertQuery;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
       auth: {
         admin: {
           createUser: jest.fn().mockResolvedValue({
@@ -705,9 +707,7 @@ describe('POST /api/admin/companies', () => {
 
     const mockSupabase = {
       from: jest.fn((table: string) => {
-        if (table === 'm_users' && !companyInsertQuery.insert.mock.calls.length) return usersCheckQuery;
-        if (table === 'm_companies') return companyInsertQuery;
-        if (table === 'm_users') return userInsertQuery;
+        if (table === 'm_users') return usersCheckQuery;
         throw new Error(`Unexpected table: ${table}`);
       }),
     };
@@ -718,6 +718,11 @@ describe('POST /api/admin/companies', () => {
     });
 
     const mockAdminClient = {
+      from: jest.fn((table: string) => {
+        if (table === 'm_companies') return companyInsertQuery;
+        if (table === 'm_users') return userInsertQuery;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
       auth: {
         admin: {
           createUser: mockCreateUser,
@@ -785,12 +790,22 @@ describe('POST /api/admin/companies', () => {
     const mockSupabase = {
       from: jest.fn((table: string) => {
         if (table === 'm_users') return usersCheckQuery;
-        if (table === 'm_companies') return companyInsertQuery;
         throw new Error(`Unexpected table: ${table}`);
       }),
     };
 
+    const mockAdminClient = {
+      from: jest.fn((table: string) => {
+        if (table === 'm_companies') return companyInsertQuery;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+      auth: {
+        admin: {},
+      },
+    };
+
     mockedCreateClient.mockResolvedValue(mockSupabase as any);
+    mockedCreateAdminClient.mockResolvedValue(mockAdminClient as any);
 
     const request = buildRequest({
       company: { name: 'テスト株式会社' },

--- a/app/api/admin/companies/route.ts
+++ b/app/api/admin/companies/route.ts
@@ -185,6 +185,8 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = await createClient();
+    // RLSバイパスのためadminクライアントを使用（site_adminのJWTはcurrent_facility_idが未設定のためWITH CHECKに失敗する）
+    const supabaseAdmin = await createAdminClient();
 
     // メールアドレス重複チェック
     const { data: existingUser } = await supabase
@@ -196,7 +198,6 @@ export async function POST(request: NextRequest) {
 
     if (existingUser) {
       // 既存ユーザーが存在する場合: last_sign_in_at を確認して再招待 or エラー
-      const supabaseAdmin = await createAdminClient();
 
       const { data: authUserData, error: authUserError } = await supabaseAdmin.auth.admin.getUserById(existingUser.id);
 
@@ -217,8 +218,8 @@ export async function POST(request: NextRequest) {
       }
 
       // パスワード未設定 → 再招待フロー
-      // Step 1: 新しい会社を先に作成
-      const { data: newCompany, error: companyError } = await supabase
+      // Step 1: 新しい会社を先に作成（RLSバイパスのためadminクライアントを使用）
+      const { data: newCompany, error: companyError } = await supabaseAdmin
         .from('m_companies')
         .insert({
           name: companyName,
@@ -248,7 +249,7 @@ export async function POST(request: NextRequest) {
 
       if (updateMetaError) {
         console.error('Failed to update user app_metadata:', updateMetaError);
-        await supabase.from('m_companies').delete().eq('id', newCompany.id);
+        await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
         return NextResponse.json(
           { success: false, error: 'Internal Server Error' },
           { status: 500 }
@@ -264,7 +265,7 @@ export async function POST(request: NextRequest) {
       });
 
       if (reinviteLinkError || !reinviteLinkData) {
-        await supabase.from('m_companies').delete().eq('id', newCompany.id);
+        await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
         try {
           await supabaseAdmin.auth.admin.updateUserById(existingUser.id, {
             app_metadata: originalAppMetadata,
@@ -282,7 +283,7 @@ export async function POST(request: NextRequest) {
 
       if (!reinviteTokenHash) {
         console.error('Failed to extract token from reinvite link');
-        await supabase.from('m_companies').delete().eq('id', newCompany.id);
+        await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
         try {
           await supabaseAdmin.auth.admin.updateUserById(existingUser.id, {
             app_metadata: originalAppMetadata,
@@ -299,10 +300,10 @@ export async function POST(request: NextRequest) {
       const reinviteBaseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
       const inviteUrlForReinvite = `${reinviteBaseUrl}/password/setup?token_hash=${reinviteTokenHash}&type=${reinviteType}`;
 
-      // m_users の情報を更新
+      // m_users の情報を更新（RLSバイパスのためadminクライアントを使用）
       const hireDateValueReinvite = body.admin_user.hire_date || getCurrentDateJST();
 
-      const { data: updatedUser, error: updateUserError } = await supabase
+      const { data: updatedUser, error: updateUserError } = await supabaseAdmin
         .from('m_users')
         .update({
           company_id: newCompany.id,
@@ -317,7 +318,7 @@ export async function POST(request: NextRequest) {
 
       if (updateUserError || !updatedUser) {
         console.error('Failed to update m_users for reinvite:', updateUserError);
-        await supabase.from('m_companies').delete().eq('id', newCompany.id);
+        await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
         try {
           await supabaseAdmin.auth.admin.updateUserById(existingUser.id, {
             app_metadata: originalAppMetadata,
@@ -360,8 +361,8 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Step 1: 会社作成
-    const { data: newCompany, error: companyError } = await supabase
+    // Step 1: 会社作成（RLSバイパスのためadminクライアントを使用）
+    const { data: newCompany, error: companyError } = await supabaseAdmin
       .from('m_companies')
       .insert({
         name: companyName,
@@ -380,8 +381,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 2: Supabase Auth ユーザー作成（current_facility_id は null: 施設はまだない）
-    const supabaseAdmin = await createAdminClient();
-
     const { data: authData, error: authCreateError } = await supabaseAdmin.auth.admin.createUser({
       email: adminEmail,
       email_confirm: false,
@@ -394,7 +393,7 @@ export async function POST(request: NextRequest) {
 
     if (authCreateError || !authData.user) {
       // ロールバック: 会社削除
-      await supabase.from('m_companies').delete().eq('id', newCompany.id);
+      await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
       throw authCreateError || new Error('Failed to create auth user');
     }
 
@@ -407,7 +406,7 @@ export async function POST(request: NextRequest) {
     if (linkError || !linkData) {
       // ロールバック
       await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
-      await supabase.from('m_companies').delete().eq('id', newCompany.id);
+      await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
       throw linkError || new Error('Failed to generate invite link');
     }
 
@@ -419,7 +418,7 @@ export async function POST(request: NextRequest) {
     if (!tokenHash) {
       console.error('Failed to extract token from invite link for company admin user');
       await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
-      await supabase.from('m_companies').delete().eq('id', newCompany.id);
+      await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
       return NextResponse.json(
         { success: false, error: 'Failed to generate valid invite link' },
         { status: 500 }
@@ -429,10 +428,10 @@ export async function POST(request: NextRequest) {
     const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
     const inviteUrl = `${baseUrl}/password/setup?token_hash=${tokenHash}&type=${type}`;
 
-    // Step 4: m_users テーブルにユーザー情報を登録
+    // Step 4: m_users テーブルにユーザー情報を登録（RLSバイパスのためadminクライアントを使用）
     const hireDateValue = body.admin_user.hire_date || getCurrentDateJST();
 
-    const { data: newUser, error: createUserError } = await supabase
+    const { data: newUser, error: createUserError } = await supabaseAdmin
       .from('m_users')
       .insert({
         id: authData.user.id,
@@ -451,7 +450,7 @@ export async function POST(request: NextRequest) {
     if (createUserError) {
       // ロールバック
       await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
-      await supabase.from('m_companies').delete().eq('id', newCompany.id);
+      await supabaseAdmin.from('m_companies').delete().eq('id', newCompany.id);
       throw createUserError;
     }
 


### PR DESCRIPTION
## 概要

`POST /api/admin/companies` で会社・管理者ユーザーを新規作成する際に、site_adminのJWTに `current_facility_id` が未設定のためRLSのWITH CHECK条件に失敗していた問題を修正。

## 変更内容

- `m_companies` / `m_users` への INSERT/UPDATE/DELETE を `createClient()` → `createAdminClient()` に変更（RLSバイパス）
- `supabaseAdmin` の初期化をPOSTハンドラ冒頭に移動し、重複宣言を削除
- READ操作（メール重複チェック等）は引き続き `createClient()`（RLS有効）を使用
- テストのモックを `supabaseAdmin.from()` に対応するよう更新

## 関連チケット

- Notion: 新規登録時にエラー。おそらくRLS (`/admin/companies/new`)

## 参考

同じパターンはPR #321（施設登録API）で修正済み。会社登録APIにも同様の対応を適用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test mocks for the company creation endpoint to use deterministic table-to-query mappings instead of conditional logic, improving test reliability.

* **Bug Fixes**
  * Updated the company creation API endpoint to consistently use elevated permissions for database operations, ensuring all write actions complete reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->