### PR TITLE
fix: 出席一覧の今日ボタンが明日の日付になるバグを修正

### DIFF
--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -261,13 +261,13 @@ export default function AttendanceListPage() {
   const [committedSearchTerm, setCommittedSearchTerm] = useState('')
   const dateInputRef = useRef<HTMLInputElement>(null)
 
-  // クライアント側でのみ初期日付を設定
-  // SSR時のタイムゾーン不一致を防ぐため
+  // クライアント側でのみ初期日付を設定（マウント時のみ）
+  // SSR時のタイムゾーン不一致を防ぐため、初期値は空文字列にして
+  // useEffectでクライアント側のみで設定する
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (!selectedDate) {
-      setSelectedDate(getTomorrowDateJST())
-    }
-  }, [selectedDate])
+    setSelectedDate(getTomorrowDateJST())
+  }, [])
 
   const fetchAttendance = useCallback(async (silent = false) => {
     // 日付が設定されるまで待つ

--- a/lib/utils/timezone.ts
+++ b/lib/utils/timezone.ts
@@ -58,15 +58,17 @@ export const formatTimeJST = (
 
 /**
  * Get current date in JST (Japan Standard Time) in YYYY-MM-DD format
+ * Uses explicit UTC+9 arithmetic to avoid locale-dependent toLocaleDateString format issues.
  */
 export const getCurrentDateJST = (): string => {
   const now = new Date();
-  return now.toLocaleDateString('ja-JP', {
-    timeZone: 'Asia/Tokyo',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).replace(/\//g, '-'); // "YYYY/MM/DD" → "YYYY-MM-DD"
+  // Convert to JST by adding 9 hours (UTC+9)
+  const jstMs = now.getTime() + 9 * 60 * 60 * 1000;
+  const jstDate = new Date(jstMs);
+  const year = jstDate.getUTCFullYear();
+  const month = String(jstDate.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(jstDate.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };
 
 /**
@@ -97,14 +99,15 @@ export const getTomorrowDateJST = (): string => {
 
 /**
  * Convert a Date object to JST date string in YYYY-MM-DD format
+ * Uses explicit UTC+9 arithmetic to avoid locale-dependent toLocaleDateString format issues.
  */
 export const toDateStringJST = (date: Date): string => {
-  return date.toLocaleDateString('ja-JP', {
-    timeZone: 'Asia/Tokyo',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).replace(/\//g, '-');
+  const jstMs = date.getTime() + 9 * 60 * 60 * 1000;
+  const jstDate = new Date(jstMs);
+  const year = jstDate.getUTCFullYear();
+  const month = String(jstDate.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(jstDate.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };
 
 /**


### PR DESCRIPTION
## Summary
- 出席一覧の「今日」ボタンを押すと明日の日付が表示されるバグを修正
- `getCurrentDateJST()` / `toDateStringJST()` を `toLocaleDateString` 依存からUTC+9明示計算に変更（`getTomorrowDateJST` と同じパターンに統一）
- `useEffect` の依存配列を `[]`（マウント時のみ）に変更し、日付リセットループを防止

## Test plan
- [ ] 出席一覧ページで「今日」ボタンを押すと今日の日付が表示される
- [ ] 「明日」ボタンを押すと明日の日付が表示される
- [ ] ページロード時のデフォルトは明日の日付になっている
- [ ] timezone.ts テスト 37件すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved date initialization logic to ensure consistent behavior on component mount.
  * Enhanced timezone handling for JST date computations to use a more reliable calculation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->