### PR TITLE
fix(attendance): モバイル・タブレットでカレンダーが開かない問題を修正

### DIFF
--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -591,13 +591,11 @@ export default function AttendanceListPage() {
                   <ChevronLeft size={18} className="text-slate-600" />
                 </button>
 
-                <button
-                  onClick={() => dateInputRef.current?.showPicker()}
+                <div
                   className="flex items-center gap-3 px-3 min-w-[200px] justify-center cursor-pointer hover:bg-gray-50 rounded transition-colors py-1 relative"
-                  aria-label="日付を選択"
                 >
-                  <Calendar size={16} className="text-indigo-600" />
-                  <span className="text-base font-bold text-slate-800">
+                  <Calendar size={16} className="text-indigo-600 pointer-events-none" />
+                  <span className="text-base font-bold text-slate-800 pointer-events-none">
                     {formatDisplayDate(selectedDate)}
                   </span>
                   <input
@@ -605,11 +603,10 @@ export default function AttendanceListPage() {
                     type="date"
                     value={selectedDate}
                     onChange={(e) => setSelectedDate(e.target.value)}
-                    className="absolute inset-0 opacity-0 w-0 h-0 pointer-events-none"
-                    tabIndex={-1}
-                    aria-hidden="true"
+                    className="absolute inset-0 opacity-0 w-full h-full cursor-pointer"
+                    aria-label="日付を選択"
                   />
-                </button>
+                </div>
 
                 <button
                   onClick={() => changeDate(1)}


### PR DESCRIPTION
## 概要

スマホ・iPadで出席一覧の日付カレンダーをタップしても開かない問題を修正。

## 原因

`input.showPicker()` はiOS Safariで非対応。また隠し `input[type="date"]` に `pointer-events-none` が付いていたため、モバイルからタップできなかった。

## 修正内容

- `<button onClick={showPicker}>` を `<div>` に変更
- 隠し `input` の `w-0 h-0 pointer-events-none` を削除し、`absolute inset-0 w-full h-full` にしてボタン全体に重ねる
- アイコン・テキストに `pointer-events-none` を付与し、input へのタップを妨げないようにした

## 動作

- PC: ネイティブカレンダーが開く（inputを直接クリック）
- スマホ・iPad: 日付エリアをタップでネイティブカレンダーが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)