### PR TITLE
fix: 取り消し操作に確認ダイアログを追加

### DIFF
--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -926,9 +926,11 @@ export default function AttendanceListPage() {
         onOpenChange={(open) => { if (!open) setCancelConfirmTarget(null) }}
         title={cancelConfirmTarget?.action === 'cancel_check_in' ? '登園を取り消しますか？' : '降園を取り消しますか？'}
         description={
-          cancelConfirmTarget?.action === 'cancel_check_in'
-            ? `${cancelConfirmTarget.childName} さんの登園記録を取り消します。この操作は元に戻せません。`
-            : `${cancelConfirmTarget?.childName} さんの降園記録を取り消します。`
+          cancelConfirmTarget
+            ? cancelConfirmTarget.action === 'cancel_check_in'
+              ? `${cancelConfirmTarget.childName} さんの登園記録を取り消します。この操作は元に戻せません。`
+              : `${cancelConfirmTarget.childName} さんの降園記録を取り消します。`
+            : undefined
         }
         onConfirm={async () => {
           if (!cancelConfirmTarget) return

--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -6,6 +6,7 @@ import { StaffLayout } from "@/components/layout/staff-layout"
 import { formatTimeJST, getCurrentDateJST, getTomorrowDateJST } from "@/lib/utils/timezone"
 import { normalizeSearch } from "@/lib/utils/kana"
 import { Button } from "@/components/ui/button"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import {
   Calendar,
   ChevronLeft,
@@ -260,6 +261,11 @@ export default function AttendanceListPage() {
   const [inputSearchTerm, setInputSearchTerm] = useState('')
   const [committedSearchTerm, setCommittedSearchTerm] = useState('')
   const dateInputRef = useRef<HTMLInputElement>(null)
+  const [cancelConfirmTarget, setCancelConfirmTarget] = useState<{
+    childId: string
+    childName: string
+    action: CancelAction
+  } | null>(null)
 
   // クライアント側でのみ初期日付を設定（マウント時のみ）
   // SSR時のタイムゾーン不一致を防ぐため、初期値は空文字列にして
@@ -495,6 +501,11 @@ export default function AttendanceListPage() {
     } catch (fetchErr) {
       console.error('Failed to refresh attendance after cancel:', fetchErr)
     }
+  }
+
+  const handleRequestCancel = (childId: string, action: CancelAction) => {
+    const child = attendanceData?.children.find(c => c.child_id === childId)
+    setCancelConfirmTarget({ childId, childName: child?.name ?? '', action })
   }
 
   const handleTimeEdit = async (childId: string, field: TimeField, timeValue: string) => {
@@ -780,7 +791,7 @@ export default function AttendanceListPage() {
                           child={child}
                           currentDate={currentDate}
                           canCancel={canCancel}
-                          onCancel={handleCancelAction}
+                          onCancel={handleRequestCancel}
                           isLoading={Boolean(actionLoading[child.child_id])}
                         />
                       </td>
@@ -854,7 +865,7 @@ export default function AttendanceListPage() {
                         child={child}
                         currentDate={currentDate}
                         canCancel={canCancel}
-                        onCancel={handleCancelAction}
+                        onCancel={handleRequestCancel}
                         isLoading={Boolean(actionLoading[child.child_id])}
                       />
                     </div>
@@ -909,6 +920,23 @@ export default function AttendanceListPage() {
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={cancelConfirmTarget !== null}
+        onOpenChange={(open) => { if (!open) setCancelConfirmTarget(null) }}
+        title={cancelConfirmTarget?.action === 'cancel_check_in' ? '登園を取り消しますか？' : '降園を取り消しますか？'}
+        description={
+          cancelConfirmTarget?.action === 'cancel_check_in'
+            ? `${cancelConfirmTarget.childName} さんの登園記録を取り消します。この操作は元に戻せません。`
+            : `${cancelConfirmTarget?.childName} さんの降園記録を取り消します。`
+        }
+        onConfirm={async () => {
+          if (!cancelConfirmTarget) return
+          await handleCancelAction(cancelConfirmTarget.childId, cancelConfirmTarget.action)
+          setCancelConfirmTarget(null)
+        }}
+        isConfirming={cancelConfirmTarget ? Boolean(actionLoading[cancelConfirmTarget.childId]) : false}
+      />
     </StaffLayout>
   )
 }

--- a/app/dashboard/_components/dashboard-client.tsx
+++ b/app/dashboard/_components/dashboard-client.tsx
@@ -696,9 +696,11 @@ export default function DashboardClient() {
         onOpenChange={(open) => { if (!open) setCancelConfirmTarget(null) }}
         title={cancelConfirmTarget?.action === 'cancel_check_in' ? '登所を取り消しますか？' : '帰宅を取り消しますか？'}
         description={
-          cancelConfirmTarget?.action === 'cancel_check_in'
-            ? `${cancelConfirmTarget.childName} さんの登所記録を取り消します。この操作は元に戻せません。`
-            : `${cancelConfirmTarget?.childName} さんの帰宅時刻を取り消します。`
+          cancelConfirmTarget
+            ? cancelConfirmTarget.action === 'cancel_check_in'
+              ? `${cancelConfirmTarget.childName} さんの登所記録を取り消します。この操作は元に戻せません。`
+              : `${cancelConfirmTarget.childName} さんの帰宅時刻を取り消します。`
+            : undefined
         }
         onConfirm={async () => {
           if (!cancelConfirmTarget) return

--- a/app/dashboard/_components/dashboard-client.tsx
+++ b/app/dashboard/_components/dashboard-client.tsx
@@ -38,6 +38,7 @@ import {
   RecordSupportSkeleton,
 } from './skeletons';
 import { updateAlertsAndKpi } from '@/lib/dashboard/optimistic-updates';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 export default function DashboardClient() {
   // Phase 1: Priority data (KPI + Alerts + Action Required)
@@ -62,6 +63,11 @@ export default function DashboardClient() {
   const [pendingActions, setPendingActions] = useState<Set<string>>(new Set());
   const [checkedInDialogOpen, setCheckedInDialogOpen] = useState(false);
   const [checkedInSortBy, setCheckedInSortBy] = useState<'grade' | 'time'>('grade');
+  const [cancelConfirmTarget, setCancelConfirmTarget] = useState<{
+    childId: string
+    childName: string
+    action: 'cancel_check_in' | 'cancel_check_out'
+  } | null>(null);
 
   // 二次データ取得済みフラグ（無限ループ防止）
   const hasFetchedSecondaryData = useRef(false);
@@ -536,7 +542,7 @@ export default function DashboardClient() {
             帰宅
           </button>
           <button
-            onClick={() => handleCancelCheckIn(child.child_id)}
+            onClick={() => setCancelConfirmTarget({ childId: child.child_id, childName: child.name, action: 'cancel_check_in' })}
             className="flex items-center gap-0.5 text-xs text-red-300 hover:text-red-500 underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
             disabled={isPending}
           >
@@ -549,7 +555,7 @@ export default function DashboardClient() {
     if (child.status === 'checked_out') {
       return (
         <button
-          onClick={() => handleCancelCheckOut(child.child_id)}
+          onClick={() => setCancelConfirmTarget({ childId: child.child_id, childName: child.name, action: 'cancel_check_out' })}
           className="flex items-center gap-0.5 text-xs text-slate-400 hover:text-slate-600 underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
           disabled={isPending}
         >
@@ -684,6 +690,27 @@ export default function DashboardClient() {
           </button>
         </div>
       )}
+
+      <ConfirmDialog
+        open={cancelConfirmTarget !== null}
+        onOpenChange={(open) => { if (!open) setCancelConfirmTarget(null) }}
+        title={cancelConfirmTarget?.action === 'cancel_check_in' ? '登所を取り消しますか？' : '帰宅を取り消しますか？'}
+        description={
+          cancelConfirmTarget?.action === 'cancel_check_in'
+            ? `${cancelConfirmTarget.childName} さんの登所記録を取り消します。この操作は元に戻せません。`
+            : `${cancelConfirmTarget?.childName} さんの帰宅時刻を取り消します。`
+        }
+        onConfirm={async () => {
+          if (!cancelConfirmTarget) return
+          if (cancelConfirmTarget.action === 'cancel_check_in') {
+            await handleCancelCheckIn(cancelConfirmTarget.childId)
+          } else {
+            await handleCancelCheckOut(cancelConfirmTarget.childId)
+          }
+          setCancelConfirmTarget(null)
+        }}
+        isConfirming={cancelConfirmTarget ? pendingActions.has(cancelConfirmTarget.childId) : false}
+      />
 
       <div className="min-h-screen text-slate-900 font-sans">
         <div className="max-w-[1600px] mx-auto">

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: React.ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  onConfirm: () => void | Promise<void>
+  isConfirming?: boolean
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = '取り消す',
+  cancelLabel = 'キャンセル',
+  onConfirm,
+  isConfirming = false,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="mx-4 max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && (
+            <DialogDescription>{description}</DialogDescription>
+          )}
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isConfirming}
+            autoFocus
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isConfirming}
+          >
+            {isConfirming ? '処理中...' : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## 概要

取り消し操作をワンタッチで実行できないよう、確認ダイアログを追加しました。

## 対応チケット

- [取り消すときは確認のポップアップ](https://www.notion.so/336092aab0148012b131e3cdd6414487)

## 変更内容

- `components/ui/confirm-dialog.tsx`: 汎用確認ダイアログコンポーネントを新規作成
- `app/dashboard/_components/dashboard-client.tsx`: 登所取り消し・帰宅取り消しボタンに確認ダイアログを追加
- `app/attendance/list/page.tsx`: 登園取り消し・降園取り消しボタンに確認ダイアログを追加

## 動作

取り消しボタンをタップ → 確認ダイアログが表示される → 「取り消す」ボタンで実行 / 「キャンセル」で閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Confirmation dialogs now appear before canceling check-in or check-out actions in the attendance list and dashboard pages, displaying the child's name and action type with real-time operation status feedback during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->