### PR TITLE
fix: AI解析ハング・出席時間編集UI・デフォルト日付の修正

### DIFF
--- a/app/api/records/personal/ai/route.ts
+++ b/app/api/records/personal/ai/route.ts
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
       apiKey,
       temperature: 0.2,
       maxOutputTokens: 1200,
-      maxRetries: 2,
+      maxRetries: 1,
     });
 
     const response = await model.invoke([new HumanMessage(prompt)]);

--- a/app/api/records/personal/ai/route.ts
+++ b/app/api/records/personal/ai/route.ts
@@ -5,6 +5,8 @@ import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { HumanMessage } from '@langchain/core/messages';
 import { buildPersonalRecordPrompt } from '@/lib/ai/prompts';
 
+export const maxDuration = 60;
+
 type ObservationTag = {
   id: string;
   name: string;
@@ -105,6 +107,7 @@ export async function POST(request: NextRequest) {
       apiKey,
       temperature: 0.2,
       maxOutputTokens: 1200,
+      maxRetries: 2,
     });
 
     const response = await model.invoke([new HumanMessage(prompt)]);

--- a/app/api/records/personal/ai/route.ts
+++ b/app/api/records/personal/ai/route.ts
@@ -79,8 +79,11 @@ export async function POST(request: NextRequest) {
     const supabase = await createClient();
     const body = await request.json();
     const text = typeof body?.text === 'string' ? body.text.trim() : '';
-    if (!text) {
-      return NextResponse.json({ success: false, error: '本文を入力してください' }, { status: 400 });
+    if (!text || text.length > 5000) {
+      return NextResponse.json(
+        { success: false, error: '本文は1〜5000文字で入力してください' },
+        { status: 400 }
+      );
     }
 
     const { data: tags, error: tagError } = await supabase
@@ -136,7 +139,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       data: {
-        prompt,
         objective,
         subjective,
         flags,

--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -20,6 +20,8 @@ import {
   ArrowUp,
   ArrowDown,
   Undo2,
+  Check,
+  X,
 } from "lucide-react"
 import {
   type ChildAttendance,
@@ -119,7 +121,7 @@ const EditableTimeField = ({
   const textClassName = field === 'in' ? 'text-emerald-600' : 'text-slate-600'
   const editTitle = field === 'in' ? 'クリックして出席時刻を修正' : 'クリックして帰宅時刻を修正'
   const settingLabel = field === 'in' ? '出席時刻を設定' : '帰宅時刻を設定'
-  const cancelOnBlurRef = useRef(false)
+  const [localValue, setLocalValue] = useState<string>(timestamp ? formatTime(timestamp) : '')
 
   if (isUpdating) {
     return (
@@ -132,35 +134,41 @@ const EditableTimeField = ({
 
   if (isEditing) {
     return (
-      <input
-        type="time"
-        defaultValue={timestamp ? formatTime(timestamp) : ''}
-        className="border border-indigo-300 rounded px-1 py-0.5 text-sm w-24 focus:outline-none focus:ring-2 focus:ring-indigo-400"
-        onBlur={(e) => {
-          const cancelled = cancelOnBlurRef.current
-          cancelOnBlurRef.current = false
-
-          if (cancelled) {
-            onCancel()
-            return
-          }
-
-          if (editingTime?.childId === child.child_id && editingTime.field === field) {
-            if (e.target.value) onCommit(child.child_id, field, e.target.value)
-            else onCancel()
-          }
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
-          if (e.key === 'Escape') {
-            e.preventDefault()
-            cancelOnBlurRef.current = true
-            onCancel()
-            e.currentTarget.blur()
-          }
-        }}
-        autoFocus
-      />
+      <div className="flex items-center gap-1">
+        <input
+          type="time"
+          value={localValue}
+          onChange={(e) => setLocalValue(e.target.value)}
+          className="border border-indigo-300 rounded px-1 py-0.5 text-sm w-24 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              if (localValue) onCommit(child.child_id, field, localValue)
+              else onCancel()
+            }
+            if (e.key === 'Escape') {
+              e.preventDefault()
+              onCancel()
+            }
+          }}
+          autoFocus
+        />
+        <button
+          type="button"
+          onClick={() => { if (localValue) onCommit(child.child_id, field, localValue); else onCancel() }}
+          className="p-1 text-green-600 hover:text-green-800"
+          title="確定"
+        >
+          <Check className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="p-1 text-slate-400 hover:text-slate-600"
+          title="キャンセル"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
     )
   }
 
@@ -264,9 +272,8 @@ export default function AttendanceListPage() {
   // クライアント側でのみ初期日付を設定（マウント時のみ）
   // SSR時のタイムゾーン不一致を防ぐため、初期値は空文字列にして
   // useEffectでクライアント側のみで設定する
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    setSelectedDate(getTomorrowDateJST())
+    setSelectedDate(getCurrentDateJST())
   }, [])
 
   const fetchAttendance = useCallback(async (silent = false) => {

--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -137,6 +137,7 @@ const EditableTimeField = ({
       <div className="flex items-center gap-1">
         <input
           type="time"
+          aria-label={field === 'in' ? '出席時刻' : '帰宅時刻'}
           value={localValue}
           onChange={(e) => setLocalValue(e.target.value)}
           className="border border-indigo-300 rounded px-1 py-0.5 text-sm w-24 focus:outline-none focus:ring-2 focus:ring-indigo-400"
@@ -155,7 +156,8 @@ const EditableTimeField = ({
         <button
           type="button"
           onClick={() => { if (localValue) onCommit(child.child_id, field, localValue); else onCancel() }}
-          className="p-1 text-green-600 hover:text-green-800"
+          className="p-2 text-green-600 hover:text-green-800"
+          aria-label="確定"
           title="確定"
         >
           <Check className="h-4 w-4" />
@@ -163,7 +165,8 @@ const EditableTimeField = ({
         <button
           type="button"
           onClick={onCancel}
-          className="p-1 text-slate-400 hover:text-slate-600"
+          className="p-2 text-slate-400 hover:text-slate-600"
+          aria-label="キャンセル"
           title="キャンセル"
         >
           <X className="h-4 w-4" />

--- a/app/attendance/list/page.tsx
+++ b/app/attendance/list/page.tsx
@@ -144,7 +144,7 @@ const EditableTimeField = ({
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               if (localValue) onCommit(child.child_id, field, localValue)
-              else onCancel()
+              // 空のときは何もしない
             }
             if (e.key === 'Escape') {
               e.preventDefault()
@@ -182,6 +182,7 @@ const EditableTimeField = ({
         className={`${textClassName} font-medium hover:underline`}
         onClick={() => onStartEdit(child.child_id, field, formatTime(timestamp))}
         title={editTitle}
+        aria-label={editTitle}
       >
         {formatTime(timestamp)}
       </button>

--- a/app/records/personal/_components/observation-editor.tsx
+++ b/app/records/personal/_components/observation-editor.tsx
@@ -1226,6 +1226,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
       clearTimeout(cancelTimer);
       setAiProcessingController(null);
       setShowCancelAiButton(false);
+      setAiProcessing(false);
     }
 
     try {

--- a/app/records/personal/_components/observation-editor.tsx
+++ b/app/records/personal/_components/observation-editor.tsx
@@ -1651,19 +1651,8 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
           )}
           {isNew && !observation && aiFailedOrCancelled && (
             <Alert className="mt-2">
-              <AlertDescription className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-                <span>AI解析をスキップして保存できます。後から再解析することもできます。</span>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => {
-                    setAiFailedOrCancelled(false);
-                    void handleCreateObservation({ skipAi: true });
-                  }}
-                  disabled={savingEdit}
-                >
-                  AI分類なしで保存
-                </Button>
+              <AlertDescription>
+                AI解析に失敗しました。本文を編集して「AI解析して保存」または「AIなしで保存」を選んでください。
               </AlertDescription>
             </Alert>
           )}
@@ -1851,28 +1840,54 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
                           onChange={(e) => setEditText(e.target.value)}
                           maxLength={OBSERVATION_BODY_MAX}
                         />
-                        <div className="flex justify-end gap-2">
+                        <div className="flex justify-end gap-2 flex-wrap">
                           {!isNew && (
                             <Button variant="outline" onClick={() => setIsEditing(false)}>
                               <X className="h-4 w-4 mr-2" /> キャンセル
                             </Button>
                           )}
-                          <Button
-                            data-testid="observation-save"
-                            className="bg-blue-600 hover:bg-blue-700"
-                            onClick={handleSaveEdit}
-                            disabled={savingEdit || !editText.trim() || (isNew && !selectedChildId)}
-                          >
-                            {savingEdit ? (
-                              <>
-                                <Loader2 className="h-4 w-4 mr-2 animate-spin" /> 保存中...
-                              </>
-                            ) : (
-                              <>
-                                <Save className="h-4 w-4 mr-2" /> 保存
-                              </>
-                            )}
-                          </Button>
+                          {isNew && aiFailedOrCancelled ? (
+                            <>
+                              <Button
+                                variant="outline"
+                                className="border-gray-300"
+                                onClick={() => {
+                                  setAiFailedOrCancelled(false);
+                                  void handleCreateObservation({ skipAi: true });
+                                }}
+                                disabled={savingEdit || !editText.trim() || !selectedChildId}
+                              >
+                                <Save className="h-4 w-4 mr-2" /> AIなしで保存
+                              </Button>
+                              <Button
+                                className="bg-purple-600 hover:bg-purple-700"
+                                onClick={() => {
+                                  setAiFailedOrCancelled(false);
+                                  void handleCreateObservation({ forceAi: true });
+                                }}
+                                disabled={savingEdit || !editText.trim() || !selectedChildId}
+                              >
+                                {savingEdit ? (
+                                  <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> 処理中...</>
+                                ) : (
+                                  <><RefreshCw className="h-4 w-4 mr-2" /> AI解析して保存</>
+                                )}
+                              </Button>
+                            </>
+                          ) : (
+                            <Button
+                              data-testid="observation-save"
+                              className="bg-blue-600 hover:bg-blue-700"
+                              onClick={handleSaveEdit}
+                              disabled={savingEdit || !editText.trim() || (isNew && !selectedChildId)}
+                            >
+                              {savingEdit ? (
+                                <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> 保存中...</>
+                              ) : (
+                                <><Save className="h-4 w-4 mr-2" /> 保存</>
+                              )}
+                            </Button>
+                          )}
                         </div>
                       </>
                     )}

--- a/app/records/personal/_components/observation-editor.tsx
+++ b/app/records/personal/_components/observation-editor.tsx
@@ -64,7 +64,9 @@ const Alert = ({
   return <div className={`rounded-md border p-4 ${baseClass} ${className || ''}`}>{children}</div>;
 };
 
-const AlertDescription = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+const AlertDescription = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={className}>{children}</div>
+);
 const OBSERVATION_BODY_MAX = 5000
 const AI_RESULT_MAX = 5000
 
@@ -339,6 +341,9 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deletingRecordId, setDeletingRecordId] = useState<string | null>(null);
   const [showContinueButton, setShowContinueButton] = useState(false);
+  const [aiProcessingController, setAiProcessingController] = useState<AbortController | null>(null);
+  const [showCancelAiButton, setShowCancelAiButton] = useState(false);
+  const [aiFailedOrCancelled, setAiFailedOrCancelled] = useState(false);
 
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [showReanalyzeConfirmDialog, setShowReanalyzeConfirmDialog] = useState(false);
@@ -723,7 +728,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
       setAiProcessing(true);
       setError('');
       try {
-        const aiResult = await runAiAnalysis(toIdText(editText.trim()));
+        const aiResult = await runAiAnalysis(toIdText(editText.trim()), new AbortController().signal);
         applyAiResult(aiResult);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'AI解析に失敗しました';
@@ -827,16 +832,42 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     );
   };
 
-  const runAiAnalysis = async (text: string) => {
-    const response = await fetch('/api/records/personal/ai', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text }),
-    });
-    const result = await response.json();
-    if (!response.ok || !result.success) {
-      throw new Error(result.error || 'AI解析に失敗しました');
+  const runAiAnalysis = async (text: string, signal: AbortSignal) => {
+    const attemptFetch = async (sig: AbortSignal) => {
+      const response = await fetch('/api/records/personal/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+        signal: sig,
+      });
+      const result = await response.json();
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || 'AI解析に失敗しました');
+      }
+      return result;
+    };
+
+    // AbortSignal.any が利用可能な場合はタイムアウトと手動キャンセルを合成する
+    const combineSignals = (userSignal: AbortSignal, timeoutMs: number): AbortSignal => {
+      if (typeof AbortSignal.timeout === 'function' && typeof (AbortSignal as { any?: unknown }).any === 'function') {
+        const timeoutSignal = AbortSignal.timeout(timeoutMs);
+        return (AbortSignal as { any: (signals: AbortSignal[]) => AbortSignal }).any([userSignal, timeoutSignal]);
+      }
+      // フォールバック: ユーザーキャンセルのみ（タイムアウトは効かないが許容範囲）
+      return userSignal;
+    };
+
+    let result;
+    try {
+      // 30秒タイムアウト付きで1回目
+      result = await attemptFetch(combineSignals(signal, 30_000));
+    } catch (e) {
+      // ユーザー手動キャンセルは即再スロー
+      if (signal.aborted) throw e;
+      // タイムアウト or ネットワークエラーなら1回だけリトライ
+      result = await attemptFetch(combineSignals(signal, 30_000));
     }
+
     const objective = result.data?.objective ?? result.data?.ai_action ?? '';
     const subjective = result.data?.subjective ?? result.data?.ai_opinion ?? '';
     const flags = normalizeTagFlags(observationTags, result.data?.flags as Record<string, unknown>);
@@ -1123,7 +1154,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     }
   };
 
-  const handleCreateObservation = async ({ forceAi = false }: { forceAi?: boolean } = {}) => {
+  const handleCreateObservation = async ({ forceAi = false, skipAi = false }: { forceAi?: boolean; skipAi?: boolean } = {}) => {
     if (savingEdit) return;
     const displayText = editText.trim();
     const text = toIdText(displayText).trim();
@@ -1141,24 +1172,59 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     }
     setSavingEdit(true);
     setError('');
-    try {
-      const hasAiOutput =
-        aiEditForm.ai_action.trim() ||
-        aiEditForm.ai_opinion.trim() ||
-        Object.values(aiEditForm.flags).some(Boolean);
-      let aiResult: AiAnalysisResult;
-      if (!forceAi && hasAiOutput) {
-        aiResult = {
-          ai_action: toIdText(aiEditForm.ai_action),
-          ai_opinion: toIdText(aiEditForm.ai_opinion),
-          flags: aiEditForm.flags,
-        };
-      } else {
-        setAiProcessing(true);
-        aiResult = await runAiAnalysis(text);
-        applyAiResult(aiResult);
-      }
 
+    const hasAiOutput =
+      aiEditForm.ai_action.trim() ||
+      aiEditForm.ai_opinion.trim() ||
+      Object.values(aiEditForm.flags).some(Boolean);
+
+    let aiResult: AiAnalysisResult;
+    let aiAnalyzed = false;
+
+    if (skipAi) {
+      // AI解析をスキップして空の結果を使う
+      aiResult = { ai_action: '', ai_opinion: '', flags: {} as Record<string, boolean> };
+    } else if (!forceAi && hasAiOutput) {
+      aiResult = {
+        ai_action: toIdText(aiEditForm.ai_action),
+        ai_opinion: toIdText(aiEditForm.ai_opinion),
+        flags: aiEditForm.flags,
+      };
+      aiAnalyzed = true;
+    } else {
+      // AI解析を実行
+      const controller = new AbortController();
+      setAiProcessingController(controller);
+      setShowCancelAiButton(false);
+      setAiFailedOrCancelled(false);
+      setAiProcessing(true);
+
+      const cancelTimer = setTimeout(() => setShowCancelAiButton(true), 8_000);
+
+      try {
+        aiResult = await runAiAnalysis(text, controller.signal);
+        applyAiResult(aiResult);
+        aiAnalyzed = true;
+      } catch (e) {
+        clearTimeout(cancelTimer);
+        setAiProcessing(false);
+        setAiProcessingController(null);
+        setShowCancelAiButton(false);
+        setAiFailedOrCancelled(true);
+        const isUserAbort = e instanceof Error && e.name === 'AbortError' && controller.signal.aborted;
+        if (!isUserAbort) {
+          const errorMessage = e instanceof Error ? e.message : 'AI解析に失敗しました';
+          setError(errorMessage);
+        }
+        setSavingEdit(false);
+        return;
+      }
+      clearTimeout(cancelTimer);
+      setAiProcessingController(null);
+      setShowCancelAiButton(false);
+    }
+
+    try {
       const observationDateStr = observationDate ? toDateStringJST(observationDate) : getCurrentDateJST();
 
       // APIに保存
@@ -1205,6 +1271,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
       setObservation(newObservation);
       setIsEditing(false);
       setEditText('');
+      setAiFailedOrCancelled(false);
 
       if (!draftId) {
         // 保存成功後はAI解析結果を表示し「続けて入力」ボタンを表示する
@@ -1219,6 +1286,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
           tag_ids: Object.entries(aiResult.flags)
             .filter(([, v]) => v)
             .map(([k]) => k),
+          is_ai_analyzed: aiAnalyzed,
         };
         setRecentObservations((prev) => [newRecentItem, ...prev.slice(0, 9)]);
         return;
@@ -1312,7 +1380,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     if (!sourceText.trim()) return;
     setAiProcessing(true);
     try {
-      const aiResult = await runAiAnalysis(toIdText(sourceText.trim()));
+      const aiResult = await runAiAnalysis(toIdText(sourceText.trim()), new AbortController().signal);
       applyAiResult(aiResult);
     } finally {
       setAiProcessing(false);
@@ -1494,6 +1562,16 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
             <div className="flex flex-col items-center gap-3">
               <Loader2 className="h-10 w-10 animate-spin text-purple-600" />
               <span className="text-lg font-medium text-gray-700">解析中...</span>
+              {showCancelAiButton && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => aiProcessingController?.abort()}
+                  className="mt-2"
+                >
+                  解析をキャンセル
+                </Button>
+              )}
             </div>
           </div>
         )}
@@ -1554,6 +1632,24 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
           {childOptionsError && (
             <Alert variant="destructive">
               <AlertDescription>{childOptionsError}</AlertDescription>
+            </Alert>
+          )}
+          {isNew && !observation && aiFailedOrCancelled && (
+            <Alert className="mt-2">
+              <AlertDescription className="flex items-center justify-between gap-2">
+                <span>AI解析をスキップして保存できます。後から再解析することもできます。</span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setAiFailedOrCancelled(false);
+                    void handleCreateObservation({ skipAi: true });
+                  }}
+                  disabled={savingEdit}
+                >
+                  AI分類なしで保存
+                </Button>
+              </AlertDescription>
             </Alert>
           )}
         </div>
@@ -2069,6 +2165,11 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
                                     </span>
                                     {item.recorded_by_name && (
                                       <span className="text-xs text-gray-500 whitespace-nowrap">{item.recorded_by_name}</span>
+                                    )}
+                                    {item.is_ai_analyzed === false && (
+                                      <Badge variant="secondary" className="text-xs bg-yellow-50 text-yellow-700 border-yellow-200">
+                                        AI未解析
+                                      </Badge>
                                     )}
                                     {tagBadges.map((tag) => (
                                       <Badge

--- a/app/records/personal/_components/observation-editor.tsx
+++ b/app/records/personal/_components/observation-editor.tsx
@@ -864,8 +864,9 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     } catch (e) {
       // ユーザー手動キャンセルは即再スロー
       if (signal.aborted) throw e;
-      // タイムアウト起因のAbortErrorのみリトライ（4xx・JSONエラー等は即スロー）
-      const isTimeoutAbort = e instanceof Error && e.name === 'AbortError';
+      // タイムアウト起因のAbortError/TimeoutErrorのみリトライ（4xx・JSONエラー等は即スロー）
+      // AbortSignal.timeout()はTimeoutError(WHATWG仕様)を投げるが旧ブラウザではAbortErrorの場合もある
+      const isTimeoutAbort = e instanceof Error && (e.name === 'TimeoutError' || e.name === 'AbortError');
       if (!isTimeoutAbort) throw e;
       // 30秒タイムアウト付きで1回リトライ
       result = await attemptFetch(combineSignals(signal, 30_000));

--- a/app/records/personal/_components/observation-editor.tsx
+++ b/app/records/personal/_components/observation-editor.tsx
@@ -61,7 +61,7 @@ const Alert = ({
   children: React.ReactNode;
 }) => {
   const baseClass = variant === 'destructive' ? 'border-red-200 bg-red-50 text-red-800' : 'border-blue-200 bg-blue-50 text-blue-800';
-  return <div className={`rounded-md border p-4 ${baseClass} ${className || ''}`}>{children}</div>;
+  return <div role="alert" className={`rounded-md border p-4 ${baseClass} ${className || ''}`}>{children}</div>;
 };
 
 const AlertDescription = ({ children, className }: { children: React.ReactNode; className?: string }) => (
@@ -864,7 +864,10 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     } catch (e) {
       // ユーザー手動キャンセルは即再スロー
       if (signal.aborted) throw e;
-      // タイムアウト or ネットワークエラーなら1回だけリトライ
+      // タイムアウト起因のAbortErrorのみリトライ（4xx・JSONエラー等は即スロー）
+      const isTimeoutAbort = e instanceof Error && e.name === 'AbortError';
+      if (!isTimeoutAbort) throw e;
+      // 30秒タイムアウト付きで1回リトライ
       result = await attemptFetch(combineSignals(signal, 30_000));
     }
 
@@ -1182,6 +1185,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     let aiAnalyzed = false;
 
     if (skipAi) {
+      setAiProcessing(false);
       // AI解析をスキップして空の結果を使う
       aiResult = { ai_action: '', ai_opinion: '', flags: {} as Record<string, boolean> };
     } else if (!forceAi && hasAiOutput) {
@@ -1558,19 +1562,29 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
     <RequireAuth>
       <div className="space-y-6">
         {aiProcessing && (
-          <div className="fixed inset-0 z-50 bg-white/80 flex items-center justify-center">
-            <div className="flex flex-col items-center gap-3">
+          <div
+            className="fixed inset-0 z-50 bg-white/80 flex items-center justify-center"
+            role="dialog"
+            aria-modal="true"
+            aria-label="AI解析中"
+          >
+            <div className="flex flex-col items-center gap-3" role="status" aria-live="polite">
               <Loader2 className="h-10 w-10 animate-spin text-purple-600" />
               <span className="text-lg font-medium text-gray-700">解析中...</span>
               {showCancelAiButton && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => aiProcessingController?.abort()}
-                  className="mt-2"
-                >
-                  解析をキャンセル
-                </Button>
+                <>
+                  <span className="text-sm text-gray-500">解析に時間がかかっています</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => aiProcessingController?.abort()}
+                    className="mt-2"
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                  >
+                    解析をキャンセル
+                  </Button>
+                </>
               )}
             </div>
           </div>
@@ -1636,7 +1650,7 @@ export function ObservationEditor({ mode, observationId, initialChildId }: Obser
           )}
           {isNew && !observation && aiFailedOrCancelled && (
             <Alert className="mt-2">
-              <AlertDescription className="flex items-center justify-between gap-2">
+              <AlertDescription className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
                 <span>AI解析をスキップして保存できます。後から再解析することもできます。</span>
                 <Button
                   size="sm"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9092,7 +9092,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary
- AI自動記録の「解析中」オーバーレイが返ってこないAPIリクエストで永遠に表示されるバグを修正
- 30秒タイムアウト + 自動1回リトライ + 8秒後キャンセルボタン表示
- キャンセル/失敗時は本文を残したまま「AI分類なしで保存」ボタンを提供
- 出席予定一覧の時刻編集が `onBlur` で即閉じる問題を修正（確定/×ボタン方式に変更）
- 出席予定一覧のデフォルト日付を「明日」→「今日」に変更

## Changes
- `app/records/personal/_components/observation-editor.tsx`: AbortController・タイムアウト・リトライ・キャンセルUI・AIなし保存導線を追加
- `app/api/records/personal/ai/route.ts`: `maxDuration=60`, `maxRetries=2` を明示
- `app/attendance/list/page.tsx`: `EditableTimeField` を確定/キャンセルボタン方式に変更、デフォルト日付を今日に

## Test plan
- [ ] `/records/personal/new` でネットワーク遅延（DevTools）設定し、保存後に「解析中」→8秒後キャンセルボタン出現確認
- [ ] キャンセル後「AI分類なしで保存」ボタン出現→保存成功確認
- [ ] 出席予定一覧で時刻クリック→他をタップしても閉じないことを確認
- [ ] 確定/×ボタンで正常に保存/キャンセルできることを確認
- [ ] 出席予定一覧が「今日」の日付でデフォルト表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancelable AI analysis with explicit cancel UI and “save without AI” option.
  * Badge for observations that haven’t been AI-analyzed.

* **Improvements**
  * Time editor now uses explicit confirm/cancel controls; default attendance date set to today; improved accessibility.
  * AI: global duration limit (60s), stricter input validation (1–5000 chars), one-time retry behavior, timeout handling, and removal of raw prompt from successful responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->